### PR TITLE
fix(viewer): update cluster assignments for Jurisdiction and Place

### DIFF
--- a/viewer/scripts/ontology-adapter.js
+++ b/viewer/scripts/ontology-adapter.js
@@ -8,7 +8,8 @@
     'ExposureUnit': 'Risk',
     'Barrier': 'Risk',
     // Context — where solutions operate and who governs them
-    'Location': 'Context',
+    'Jurisdiction': 'Context',
+    'Place': 'Context',
     'UrbanSystem': 'Context',
     'Stakeholder': 'Context',
     'Supplier': 'Finance',


### PR DESCRIPTION
## Summary
- Replace stale `Location` entry in `CLUSTER_ASSIGNMENTS` with `Jurisdiction` and `Place`
- Both types now map to the `Context` cluster so they plot correctly in the network graph

## Test plan
- [ ] Load viewer and verify Jurisdiction and Place nodes appear in the Context cluster arc