### PR TITLE
feat(ontology): v0.6 — action/goal/project-level edges + land FUNDED_BY

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ vocabularies that model how cities adapt to climate change. Versioned JSON in
 `ontology/`, displayed by a browser-based viewer in `viewer/`, deployed to
 [ontology.adaptbase.us](https://ontology.adaptbase.us/) via GitHub Pages.
 
-**Current version:** v0.5.1 (2026-05-19)
+**Current version:** v0.6 (2026-06-30)
 
 ## Repo layout
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ maps the entities, relationships, and vocabularies needed to organize, compare, 
 analyze how cities respond to climate hazards.
 
 **Live viewer:** [ontology.adaptbase.us](https://ontology.adaptbase.us/)
-**Current version:** v0.5.1 (2026-05-19)
+**Current version:** v0.6 (2026-06-30)
 
 ---
 

--- a/ontology/decisions-log.md
+++ b/ontology/decisions-log.md
@@ -1,14 +1,55 @@
 # Ontology Design Decisions Log
 
 **Project:** Resilience Scanner - Climate Adaptation Solutions Ontology  
-**Version:** 0.5.0  
-**Last Updated:** 2026-05-15
+**Version:** 0.6  
+**Last Updated:** 2026-06-30
 
 ---
 
 ## Purpose
 
 This log documents key design decisions in the ontology development process, including rationale, alternatives considered, and implications for future work.
+
+---
+
+## Decision 30 (v0.6): Action-, goal-, and project-level edges for CDP / 2024 fact-table data; land the FUNDED_BY relationship
+
+**Date:** 2026-06-30
+**Context:** CDP city-action records and the 2024 resilience "fact table" tag hazards, sectors, and funders at the **action** and **resilience-goal** grain. The ontology could previously express these only at the **plan** grain (`Plan ADDRESSES Hazard`, `Plan TARGETS UrbanSystem`) or via the solution path (`Solution OPERATES_ON UrbanSystem`, `Solution MITIGATES Hazard`). So an action that addresses a hazard, a goal that targets a hazard, an action that names a funder, or a capital project whose system domain is known were all either downgraded to a plan-level statement, mis-attributed, or buried in a property. Most CDP actions are free-text operational actions that cannot be resolved to a canonical `Solution`, so an `Action → Solution → …` path is not a viable carrier for these fields.
+
+### Decision
+
+Bump to **v0.6** (minor — schema change). Add six relationship rows, **reusing existing relationship ids** across new `(source, target)` pairs. The viewer and graph model key edges by `id + source + target` (see `viewer/scripts/ontology-adapter.js`), and v0.2 already established this duplicate-id pattern (`DEPLOYED_IN`, `SPECIFIES`, `USES_INSTRUMENT`, `PRODUCES`, `IMPLEMENTED_BY`), so the grains coexist cleanly.
+
+| CDP / 2024 fact-table field | New edge | Grain |
+|---|---|---|
+| `climate_hazard_s_that_action` | `ADDRESSES` (Action → Hazard) | action |
+| `goal_hazards` | `ADDRESSES` (ResilienceGoal → Hazard) | resilience goal |
+| `sectors_adaptation_action` | `TARGETS` (Action → UrbanSystem) | action |
+| `project_area` | `TARGETS` (CapitalProject → UrbanSystem) | capital project |
+| `funding_source_s` | `FUNDED_BY` (Action → FinancingSource) | action |
+| — (latent bug fix) | `FUNDED_BY` (CapitalProject → FinancingSource) | capital project |
+
+### Why reuse `ADDRESSES` / `TARGETS` rather than mint new ids
+
+`ADDRESSES` already means "this thing identifies/targets this hazard" and `TARGETS` already means "this thing focuses on this urban system." The action/goal/project versions are the same semantics at a finer grain; distinguishing them by `source` (not by a new id like `ACTION_ADDRESSES`) keeps the relationship vocabulary small and matches the established duplicate-id convention. The `Action`/`ResilienceGoal` `ADDRESSES Hazard` rows deliberately omit `assessment_scope`/`assessment_year` — those are plan-assessment concepts that don't apply at the action/goal grain.
+
+### Why `CapitalProject TARGETS UrbanSystem` reverses part of Decision 28
+
+The v0.2 "CapitalProject Edge Economy" decision deliberately omitted a direct `CapitalProject → UrbanSystem` edge and collapsed system domain into the `asset_class` property, reasoning it was reachable via `REALIZES Action → IMPLEMENTS Solution → OPERATES_ON UrbanSystem`. In practice that path rarely resolves (most CIP/CDP project rows never reach a canonical Solution), and `asset_class` is a coarse local annotation, not a queryable graph edge. CDP `project_area` gives the system domain directly. v0.6 therefore adds the direct edge using `TARGETS` (program-grain "focuses on this system"), **not** `OPERATES_ON` (Solution-grain "deployed within/modifies"). `asset_class` is retained alongside the edge as the budget-document's own annotation.
+
+### Why land `FUNDED_BY` now
+
+`FUNDED_BY` was referenced in v0.2's `change_history`, the "Resilience Finance — Five-Axis Split" design note, and the `CapitalProject USES_INSTRUMENT` notes — all stating `CapitalProject FUNDED_BY FinancingSource` — but **no `FUNDED_BY` relationship object was ever added to the relationships array** (Decision 28 claimed it; it was never implemented). Adding the requested `Action FUNDED_BY FinancingSource` is the moment to also land the long-referenced `CapitalProject FUNDED_BY FinancingSource` row, completing the documented financing chain `FinancingSource ←FUNDED_BY← CapitalProject →USES_INSTRUMENT→ FinancialInstrument ←CHANNELS_THROUGH← FinancingSource`. `FUNDED_BY` names *who provides the money*; `USES_INSTRUMENT` names *the structural form of the capital* — they are complementary, not redundant.
+
+### Also corrected
+
+Stale metadata counts: `relationships_count` 51 → 60 (the v0.5.1 array already held 54 rows but declared 51; +6 new v0.6 rows) and `types_count` 21 → 22 (`Place`, added in v0.5.0, was never counted).
+
+### Implications / not done
+
+- No new entity types, vocabularies, or enum values; no viewer code changes (rendering is generic and all six entities already have cluster assignments).
+- Provenance: every new row carries `claim_ids` (optional), consistent with the action/plan-grain convention.
 
 ---
 

--- a/ontology/framework-crosswalk.md
+++ b/ontology/framework-crosswalk.md
@@ -148,6 +148,20 @@ GCoM CRF is the strongest alignment case. Our planning + solutions nodes were im
 
 **Standardization opportunity**: GCoM uses a specific action category vocabulary (~20 categories). We should create a crosswalk from our `Solution.category_id` values to GCoM categories and document it in `vocabularies/`. This is metadata work, not a schema change.
 
+### CDP action-, goal-, and project-grain fields → Ontology edges (v0.6)
+
+CDP city-action rows and the 2024 resilience fact table tag hazards, sectors, and funders at the **action** and **resilience-goal** grain — not the plan grain. v0.6 added typed edges so these map to queryable graph edges instead of being downgraded to plan-level statements, mis-attributed, or buried in a property. The edges reuse the existing `ADDRESSES` / `TARGETS` / `FUNDED_BY` relationship ids, distinguished by `source` (see decisions-log Decision 30).
+
+| CDP / 2024 fact-table field | Ontology edge | Coverage | Notes |
+|---|---|---|---|
+| `climate_hazard_s_that_action` | `ADDRESSES` (Action → Hazard) | **Full** | Action-grain; not the same as plan-level `Plan ADDRESSES Hazard` or solution-level `Solution MITIGATES Hazard` |
+| `goal_hazards` | `ADDRESSES` (ResilienceGoal → Hazard) | **Full** | Goal-grain risk target; not downgraded to plan- or action-level |
+| `sectors_adaptation_action` | `TARGETS` (Action → UrbanSystem) | **Full** | Action-grain; no `Action → Solution` resolution required |
+| `project_area` | `TARGETS` (CapitalProject → UrbanSystem) | **Full** | Promotes system domain from `CapitalProject.asset_class` property to a queryable edge |
+| `funding_source_s` | `FUNDED_BY` (Action → FinancingSource) | **Full** | Action-grain funder; no `CapitalProject` / `FinancialInstrument` resolution required |
+
+> The GCoM CRF table above already mapped `FUNDED_BY.amount_usd` and `FinancingSource.source_type`. The `FUNDED_BY` relationship itself was referenced from v0.2 but not actually defined in the ontology until v0.6, which adds both the `Action → FinancingSource` and `CapitalProject → FinancingSource` rows.
+
 ---
 
 ## 4. RCC Shocks + Stresses Integration Decision

--- a/ontology/ontology-v0.6.json
+++ b/ontology/ontology-v0.6.json
@@ -1,0 +1,3390 @@
+{
+  "version": "v0.6",
+  "update_note": "Action-, goal-, and project-level edges for CDP city-action and 2024 fact-table data: Action ADDRESSES Hazard, Action TARGETS UrbanSystem, Action FUNDED_BY FinancingSource, ResilienceGoal ADDRESSES Hazard, CapitalProject TARGETS UrbanSystem. Also lands the FUNDED_BY relationship (CapitalProject → FinancingSource) referenced since v0.2 but never defined.",
+  "updated": "2026-06-30T00:00:00.000Z",
+  "domain": "urban-climate-adaptation",
+  "domain_label": "Urban Climate Adaptation and Resilience Solutions",
+  "types": [
+    {
+      "id": "Solution",
+      "label": "Solution",
+      "definition": "A climate adaptation intervention, technology, or approach deployed or proposed to reduce vulnerability or increase adaptive capacity. Classified by identity (what it IS); function is expressed via typed relationships (MITIGATES, OPERATES_ON, WORKS_BY, PRODUCES).",
+      "properties": [
+        {
+          "id": "name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "alternative_names",
+          "type": "array<string>",
+          "required": false
+        },
+        {
+          "id": "description",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "category_id",
+          "type": "string",
+          "required": true,
+          "vocabulary": "solution-categories"
+        },
+        {
+          "id": "subcategory_id",
+          "type": "string",
+          "required": false,
+          "vocabulary": "solution-categories"
+        },
+        {
+          "id": "ipcc_action_types",
+          "type": "array<enum>",
+          "values": [
+            "structural_physical",
+            "social",
+            "institutional",
+            "ecosystem_based"
+          ]
+        },
+        {
+          "id": "year_of_deployment",
+          "type": "integer",
+          "required": false
+        },
+        {
+          "id": "maturity_level",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "emerging",
+            "demonstrated",
+            "established"
+          ],
+          "note": "Solution-class maturity. emerging = pilot/prototype/first-of-kind; demonstrated = working reference deployments, not yet mainstream; established = standard practice with broad replication. Distinct from Outcome.evidence_level (strength of evidence for a specific outcome)."
+        },
+        {
+          "id": "equity_focus",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "none",
+            "co_benefit",
+            "primary_target"
+          ],
+          "note": "Whether equity is a primary design target (primary_target), a documented secondary benefit (co_benefit), or not addressed (none). Distinct from whether equity outcomes are documented in Outcome nodes — this classifies the solution's design intent."
+        },
+        {
+          "id": "target_populations",
+          "type": "array<string>",
+          "required": false,
+          "vocabulary": "vulnerable-populations",
+          "note": "Specific vulnerable population groups the solution is designed to serve or has demonstrated benefits for. Bound to vulnerable-populations vocabulary."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "solution-categories",
+          "field": "category_id, subcategory_id"
+        },
+        {
+          "vocab": "enums",
+          "field": "ipcc_action_types, equity_focus"
+        },
+        {
+          "vocab": "vulnerable-populations",
+          "field": "target_populations"
+        }
+      ],
+      "notes": "Solutions are reusable classes of intervention, independent of any specific deployment location or plan.",
+      "extract_hint": "Look for named interventions, technologies, programs, or projects described as addressing climate risks — e.g., 'green roof program', 'flood early warning system', 'mangrove restoration initiative'."
+    },
+    {
+      "id": "Hazard",
+      "label": "Hazard",
+      "definition": "A climate-related threat or stressor that adaptation solutions address. Structured by the UNDRR-ISC Hazard Information Profiles (HIPs) 2025 taxonomy — 7 hazard clusters, 50 specific hazards. Individual hazards source from C40/Arup (climate-related) or Resilient Cities Catalysts (non-climate acute shocks and slow-onset stresses).",
+      "properties": [
+        {
+          "id": "hazard_id",
+          "type": "string",
+          "required": true,
+          "vocabulary": "hazards"
+        },
+        {
+          "id": "hazard_category",
+          "type": "enum",
+          "required": true,
+          "vocabulary": "hazards",
+          "note": "UNDRR HIPs 2025 cluster ID. Replaces the 13 C40/Arup categories as of v0.4.",
+          "values": [
+            "meteorological_hydrological",
+            "geohazards",
+            "environmental",
+            "biological",
+            "chemical",
+            "technological",
+            "societal"
+          ]
+        },
+        {
+          "id": "hazard_source",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "c40_arup",
+            "rcc"
+          ],
+          "note": "Vocabulary source. c40_arup = climate hazards (default); rcc = non-climate acute shocks from Resilient Cities Catalysts taxonomy."
+        },
+        {
+          "id": "c40_arup_category",
+          "type": "string",
+          "required": false,
+          "note": "Legacy C40/Arup category ID for crosswalk (e.g., 'flood', 'wind', 'extreme_temperature_hot'). Populated from hazards.json c40_arup_category field. Null for RCC-sourced hazards."
+        },
+        {
+          "id": "frequency",
+          "type": "string",
+          "required": false,
+          "note": "How often the hazard occurs (e.g., 'annual', 'decadal', '1-in-50-year'). Free-text to accommodate diverse source formats."
+        },
+        {
+          "id": "severity",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "low",
+            "moderate",
+            "high",
+            "severe"
+          ],
+          "note": "General severity level of this hazard as documented or assessed."
+        },
+        {
+          "id": "trend",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "increasing",
+            "stable",
+            "decreasing",
+            "uncertain"
+          ],
+          "note": "Projected or observed trend in hazard frequency/severity under climate change."
+        },
+        {
+          "id": "return_period",
+          "type": "string",
+          "required": false,
+          "note": "Statistical return interval for extreme events (e.g., '1-in-100-year', '1-in-20-year'). Free-text."
+        },
+        {
+          "id": "climate_scenario",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "SSP1-2.6",
+            "SSP2-4.5",
+            "SSP3-7.0",
+            "SSP5-8.5",
+            "other"
+          ],
+          "note": "IPCC AR6 SSP scenario under which this hazard characterization applies. Extractor note: RCP labels (RCP 4.5 ≈ SSP2-4.5, RCP 8.5 ≈ SSP5-8.5) from pre-2023 plans should be mapped to the nearest SSP equivalent."
+        },
+        {
+          "id": "climate_scenario_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when climate_scenario = other."
+        },
+        {
+          "id": "projection_year",
+          "type": "integer",
+          "required": false,
+          "note": "Target year for which the hazard characterization applies (e.g., 2050, 2080). Enables longitudinal comparison across successive plans."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "hazards",
+          "field": "hazard_id, hazard_category",
+          "note": "UNDRR HIPs 2025 — primary vocabulary for climate hazards (7 clusters, 50 hazards)"
+        },
+        {
+          "vocab": "hazards",
+          "field": "hazard_id",
+          "note": "RCC non-climate acute shocks (hazard_source=rcc). See alignment/framework-crosswalk.md §4.1."
+        }
+      ],
+      "notes": "Slow-onset stresses (sea level rise, environmental degradation) map here under the environmental cluster in the UNDRR HIPs 2025 structure.",
+      "extract_hint": "Look for named climate threats, weather extremes, or environmental stressors — e.g., 'urban heat island', 'coastal flooding', 'drought', 'sea level rise'. Also look for non-climate shocks when flagged (earthquakes, pandemics)."
+    },
+    {
+      "id": "UrbanSystem",
+      "label": "Urban System",
+      "definition": "A physical, ecological, or socio-economic urban subsystem that a solution operates on or protects. Hierarchical taxonomy: sector, subsector, system. Optional infrastructure properties describe physical state when applicable.",
+      "properties": [
+        {
+          "id": "system_id",
+          "type": "string",
+          "required": true,
+          "vocabulary": "urban-systems"
+        },
+        {
+          "id": "sector",
+          "type": "enum",
+          "required": true,
+          "vocabulary": "urban-systems",
+          "values": [
+            "built_environment",
+            "mobility_transport",
+            "hydrological_water",
+            "energy_telecom",
+            "urban_ecology",
+            "socioeconomic_health",
+            "governance_finance",
+            "agriculture__food_systems",
+            "emergency__disaster_management"
+          ]
+        },
+        {
+          "id": "subsector",
+          "type": "string",
+          "required": false,
+          "vocabulary": "urban-systems"
+        },
+        {
+          "id": "condition",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "excellent",
+            "good",
+            "fair",
+            "poor",
+            "critical"
+          ],
+          "note": "Current condition or state of infrastructure."
+        },
+        {
+          "id": "capacity",
+          "type": "string",
+          "required": false,
+          "note": "Capacity metric (e.g., '10,000 m³/day', '500 people')."
+        },
+        {
+          "id": "service_coverage",
+          "type": "string",
+          "required": false,
+          "note": "Population or area served (e.g., '85% of district')."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "urban-systems",
+          "field": "system_id, sector, subsector",
+          "note": "Custom hierarchical taxonomy for climate adaptation (9 sectors, 50+ systems)"
+        }
+      ],
+      "notes": "Infrastructure properties (condition, capacity) are optional — used when physical infrastructure state is documented.",
+      "extract_hint": "Look for references to urban infrastructure, services, or systems — e.g., 'stormwater drainage', 'public transit', 'power grid', 'urban canopy', 'housing stock', 'water treatment'."
+    },
+    {
+      "id": "Mechanism",
+      "label": "Mechanism",
+      "definition": "The functional adaptation process by which a solution achieves its physical or operational effect (e.g., absorb, redirect, harden, monitor, sense and detect, forecast and model). Strictly functional/operational — financial and governance mechanisms are captured by FinancialInstrument and EnablingCondition respectively.",
+      "properties": [
+        {
+          "id": "mechanism_type",
+          "type": "enum",
+          "required": true,
+          "note": "Functional adaptation process. Must be physical/operational, not financial or governance. Use values from mechanism_vocabulary in enums; use other + mechanism_type_other_description for outliers.",
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "mechanism_vocabulary"
+          }
+        },
+        {
+          "id": "description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description of how the mechanism works."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "mechanism_vocabulary"
+        }
+      ],
+      "notes": "See also: FinancialInstrument (financial mechanisms), EnablingCondition (governance enablers).",
+      "extract_hint": "Look for HOW a solution works — verbs and processes like 'absorbs runoff', 'redirects floodwater', 'monitors soil moisture', 'detects heat anomalies', 'hardens infrastructure against wind load'."
+    },
+    {
+      "id": "Stakeholder",
+      "label": "Stakeholder",
+      "definition": "Any individual, group, or organization — such as residents, businesses, government agencies, and NGOs — that can affect or be affected by urban adaptation projects. Covers governance, implementation, and community roles. Commercial suppliers are modeled separately as Supplier.",
+      "properties": [
+        {
+          "id": "name",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "stakeholder_type",
+          "type": "enum",
+          "required": true,
+          "values": [
+            "municipal_government",
+            "regional_government",
+            "national_government",
+            "utility",
+            "private_sector",
+            "ngo",
+            "community",
+            "academic",
+            "international_organization"
+          ]
+        },
+        {
+          "id": "role",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "target_populations",
+          "type": "array<string>",
+          "required": false,
+          "vocabulary": "vulnerable-populations",
+          "note": "Vulnerable population group(s) this stakeholder primarily represents, serves, or advocates for. Bound to vulnerable-populations vocabulary."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "actor_type"
+        },
+        {
+          "vocab": "vulnerable-populations",
+          "field": "target_populations"
+        }
+      ],
+      "notes": "Represents both implementing actors and their roles. Instances can be generic (e.g., 'municipal_government') or named entities (e.g., 'New York City Department of Environmental Protection').",
+      "extract_hint": "Look for named organizations, agencies, community groups, or actor types involved in planning or implementing adaptation — e.g., 'city planning department', 'local NGO', 'neighborhood association', 'utility company'."
+    },
+    {
+      "id": "Jurisdiction",
+      "label": "Jurisdiction",
+      "definition": "A geographic administrative unit — city, region, state, county, or other governed territory — where adaptation solutions are implemented or plans apply. Identified by Wikidata QID as canonical PK. Supports hierarchical nesting via the WITHIN relationship.",
+      "properties": [
+        {
+          "id": "name",
+          "type": "string",
+          "required": true,
+          "note": "Primary English name of the jurisdiction."
+        },
+        {
+          "id": "name_local",
+          "type": "string",
+          "required": false,
+          "note": "Name in the local/official language if different from English name."
+        },
+        {
+          "id": "aliases",
+          "type": "array<string>",
+          "required": false,
+          "note": "Alternate names, historical names, or common abbreviations."
+        },
+        {
+          "id": "wikidata_qid",
+          "type": "string",
+          "required": true,
+          "note": "Wikidata item identifier (e.g. Q60 for New York City). Canonical primary key — globally unique, CC0 licensed."
+        },
+        {
+          "id": "jurisdiction_kind",
+          "type": "string",
+          "required": true,
+          "vocabulary": "jurisdiction-kind",
+          "note": "Administrative type of jurisdiction. Bound to jurisdiction-kind vocabulary."
+        },
+        {
+          "id": "admin_level",
+          "type": "integer",
+          "required": false,
+          "note": "OSM-style administrative level hint (2=country, 4=state/province, 6=county, 8=municipality). Loose hint for display/sorting, not a strict hierarchy."
+        },
+        {
+          "id": "country_iso",
+          "type": "string",
+          "required": false,
+          "note": "ISO 3166-1 alpha-2 country code (e.g. US, GB, IN)."
+        },
+        {
+          "id": "iso_3166_2",
+          "type": "string",
+          "required": false,
+          "note": "ISO 3166-2 subdivision code (e.g. US-FL, GB-LND)."
+        },
+        {
+          "id": "geometry",
+          "type": "object",
+          "required": false,
+          "note": "GeoJSON Point from Wikidata P625 (centroid). Polygons deliberately excluded to avoid ODbL contamination from OSM."
+        },
+        {
+          "id": "population",
+          "type": "integer",
+          "required": false,
+          "note": "Population from Wikidata P1082. City or administrative unit level."
+        },
+        {
+          "id": "population_year",
+          "type": "integer",
+          "required": false,
+          "note": "Year of the population figure (from Wikidata qualifier)."
+        },
+        {
+          "id": "climate_zone",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "tropical",
+            "dry",
+            "temperate",
+            "continental",
+            "polar",
+            "other"
+          ],
+          "note": "Köppen climate classification. Enables cross-jurisdiction comparability."
+        },
+        {
+          "id": "coastal_status",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "coastal",
+            "inland",
+            "island",
+            "other"
+          ],
+          "note": "Whether the jurisdiction is coastal, inland, or island. Relevant to flood and storm surge exposure."
+        },
+        {
+          "id": "income_classification",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "high_income",
+            "upper_middle_income",
+            "lower_middle_income",
+            "low_income",
+            "other"
+          ],
+          "note": "World Bank income group classification."
+        },
+        {
+          "id": "codes",
+          "type": "object",
+          "required": false,
+          "note": "Passive crosswalk pointers to external geographic databases. Keys: osm_relation_id (integer), geonames_id (integer), gadm_gid (string), oecd_fua_code (string). Reference only — no data imported from restricted-license sources."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "jurisdiction-kind",
+          "field": "jurisdiction_kind"
+        }
+      ],
+      "notes": "Jurisdictions are administrative/governed territories. Non-jurisdictional geographic features (watersheds, corridors, sites) use the Place type instead. Wikidata QID is the canonical join key, replacing the legacy loc_id integer.",
+      "extract_hint": "Look for named administrative units — cities, counties, states, regions, districts, municipalities — e.g., 'Miami', 'Rotterdam', 'Maharashtra', 'King County'. Do NOT use for natural features like watersheds or corridors."
+    },
+    {
+      "id": "Place",
+      "label": "Place",
+      "definition": "A non-jurisdictional geographic feature relevant to adaptation — a watershed, corridor, coastline, or specific site. Anchored to a Jurisdiction via WITHIN.",
+      "properties": [
+        {
+          "id": "name",
+          "type": "string",
+          "required": true,
+          "note": "Name of the geographic feature."
+        },
+        {
+          "id": "place_type",
+          "type": "enum",
+          "required": true,
+          "values": [
+            "watershed",
+            "corridor",
+            "coastline",
+            "site",
+            "park",
+            "infrastructure_zone",
+            "other"
+          ],
+          "note": "Category of non-jurisdictional geographic feature."
+        },
+        {
+          "id": "geometry",
+          "type": "object",
+          "required": false,
+          "note": "GeoJSON geometry (Point, LineString, Polygon, or MultiPolygon)."
+        },
+        {
+          "id": "description",
+          "type": "string",
+          "required": false,
+          "note": "Brief description of the place and its relevance to adaptation."
+        },
+        {
+          "id": "wikidata_qid",
+          "type": "string",
+          "required": false,
+          "note": "Wikidata item identifier if one exists. Many places (specific sites, small parks) will not have one."
+        }
+      ],
+      "vocabulary_bindings": [],
+      "notes": "Place captures geographic features that are not administrative units: watersheds, river corridors, coastlines, specific project sites. Always linked to a containing Jurisdiction via WITHIN.",
+      "extract_hint": "Look for named non-administrative geographic features — e.g., 'Mekong Delta', 'downtown waterfront corridor', 'Biscayne Bay watershed', 'Central Park'. Do NOT use for cities, counties, or other administrative units."
+    },
+    {
+      "id": "ResilienceGoal",
+      "label": "Resilience Goal",
+      "definition": "A high-level resilience objective from the City Resilience Framework 2024 (22 goals across 4 dimensions). Bridges the planning and solutions domains: plans set goals, solutions claim to contribute to goals, actions target goals, and outcomes demonstrate progress on goals.",
+      "properties": [
+        {
+          "id": "goal_id",
+          "type": "string",
+          "required": true,
+          "vocabulary": "crf-goals"
+        },
+        {
+          "id": "dimension",
+          "type": "enum",
+          "required": true,
+          "vocabulary": "crf-goals",
+          "values": [
+            "health_wellbeing",
+            "economy_society",
+            "infrastructure_environment",
+            "leadership_planning"
+          ]
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "crf-goals",
+          "field": "goal_id, dimension",
+          "note": "City Resilience Framework 2024 v2 (Resilient Cities Network) - 22 goals"
+        }
+      ],
+      "notes": "Upper ontology entity bridging planning (prescriptive) and solutions (evaluative). Four epistemic tiers connect to ResilienceGoal: SETS_GOAL (plan aspiration), TARGETS_GOAL (action intent), CONTRIBUTES_TO (solution claim), DEMONSTRATES_PROGRESS_ON (measured evidence). v0.6 added ResilienceGoal ADDRESSES Hazard (from the 2024 fact-table goal_hazards field) — a goal-level risk target capturing which hazards a resilience objective addresses.",
+      "extract_hint": "Look for references to resilience objectives, CRF goals, or high-level targets — e.g., 'improve public health outcomes', 'ensure continuity of critical services', 'support livelihoods and employment', 'promote cohesive communities'."
+    },
+    {
+      "id": "Outcome",
+      "label": "Outcome",
+      "definition": "A measured or observed result of implementing a solution or action, including effectiveness indicators, co-benefits, and failure modes.",
+      "properties": [
+        {
+          "id": "outcome_type",
+          "type": "enum",
+          "required": true,
+          "note": "Category: effectiveness_indicator, co_benefit, failure_mode, maladaptation (solution worked as intended but transferred or increased risk elsewhere), or other.",
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "outcome_type"
+          }
+        },
+        {
+          "id": "outcome_type_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when outcome_type = other."
+        },
+        {
+          "id": "co_benefit_type",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "public_health",
+            "ecological",
+            "economic",
+            "social_cohesion",
+            "carbon_sequestration",
+            "aesthetic_recreational",
+            "asset_protection",
+            "revenue_stability",
+            "operational_cost_reduction",
+            "tax_base_protection",
+            "service_continuity",
+            "other"
+          ],
+          "note": "Populated only when outcome_type = co_benefit. Classifies the type of co-benefit. v0.2 added five finance-relevant categories (asset_protection, revenue_stability, operational_cost_reduction, tax_base_protection, service_continuity) to support resilience-finance valuation."
+        },
+        {
+          "id": "monetized_value_usd",
+          "type": "number",
+          "required": false,
+          "note": "Monetary value of the outcome in USD. For co-benefits this is the avoided-cost or generated-value figure (asset protection, revenue stability, etc.). v0.2."
+        },
+        {
+          "id": "value_recurrence",
+          "type": "enum",
+          "required": false,
+          "vocabulary": "enums",
+          "values": [
+            "one_time",
+            "annual",
+            "lifetime"
+          ],
+          "note": "How the monetized value recurs. one_time: lump-sum (e.g., avoided one-event damage). annual: per-year (e.g., recurring stormwater fee reduction). lifetime: integrated over the asset life. v0.2."
+        },
+        {
+          "id": "valuation_method",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description of how the monetary value was derived (e.g., 'FEMA Benefit-Cost Analysis', 'avoided damages estimate', 'agency-modeled benefit shed'). v0.2."
+        },
+        {
+          "id": "beneficiary_program",
+          "type": "array<enum>",
+          "required": false,
+          "vocabulary": "enums",
+          "values": [
+            "transportation",
+            "parks_recreation",
+            "public_safety",
+            "public_health",
+            "housing",
+            "schools",
+            "water_utilities",
+            "energy_utilities",
+            "pensions",
+            "general_revenue",
+            "other"
+          ],
+          "note": "Other municipal programs that benefit from this outcome. Captures cross-program 'ripple effects' — e.g., green stormwater infrastructure benefits both water utilities (reduced stormwater treatment cost) and parks (recreational space). v0.2."
+        },
+        {
+          "id": "co_benefit_type_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when co_benefit_type = other."
+        },
+        {
+          "id": "description",
+          "type": "string",
+          "required": true,
+          "note": "Free-text description of the outcome."
+        },
+        {
+          "id": "evidence_level",
+          "type": "enum",
+          "required": false,
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "evidence_level"
+          }
+        },
+        {
+          "id": "justice_dimension",
+          "type": "array<enum>",
+          "required": false,
+          "note": "Justice dimension(s) documented in this outcome. Based on Shi (2024) equity rubric: distributive = who bears costs/benefits; procedural = who participates in decisions; recognitional = whose knowledge/experience is acknowledged; epistemic = how knowledge is produced and whose expertise counts.",
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "justice_dimension"
+          }
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "outcome_type, evidence_level, justice_dimension, value_recurrence, beneficiary_program"
+        }
+      ],
+      "notes": "The outcome_type property differentiates between categories. Effectiveness indicators have additional Indicator children with baseline/target/measured values. v0.2 added monetized_value_usd, value_recurrence, valuation_method, and beneficiary_program for resilience-finance valuation. Outcomes attach to Solution (PRODUCES), Action (RESULTS_IN), or CapitalProject (PRODUCES). v0.3: FinancialInstrument may link here via CONTINGENT_ON for pay-for-success instruments.",
+      "extract_hint": "Look for reported results, measured impacts, observed benefits, or documented failures — e.g., 'reduced flood events by 40%', 'improved air quality as co-benefit', 'system failed during extreme heat event'."
+    },
+    {
+      "id": "Indicator",
+      "label": "Indicator",
+      "definition": "A specific, measurable metric used to assess solution or action effectiveness (e.g., 'flood events per year reduced from 12 to 3').",
+      "properties": [
+        {
+          "id": "indicator_name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "baseline",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "target",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "measured_value",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "unit",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "data_source",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "recorded_year",
+          "type": "integer",
+          "required": false,
+          "note": "Year the indicator measurement was recorded."
+        },
+        {
+          "id": "measurement_period",
+          "type": "string",
+          "required": false,
+          "note": "Time period over which the indicator was measured (e.g., '2019-2022', 'annual average 2020'). Free-text."
+        }
+      ],
+      "vocabulary_bindings": [],
+      "notes": "Child of Outcome node. Captures quantified measurements. Baseline/target/measured_value structure supports before-after analysis and target tracking.",
+      "extract_hint": "Look for quantified metrics with numbers, units, baselines, or targets — e.g., 'reduced from 12 to 3 events per year', 'target: 50% reduction in heat-related mortality', 'baseline PM2.5 of 35 µg/m³'."
+    },
+    {
+      "id": "Plan",
+      "label": "Plan",
+      "definition": "A climate adaptation or resilience planning document that binds together goals, prescribed solutions, actions, and policy frameworks. Plans are forward-looking: they set targets, specify interventions, and establish implementation timelines.",
+      "properties": [
+        {
+          "id": "plan_type",
+          "type": "enum",
+          "required": true,
+          "values": [
+            "climate_action_plan",
+            "resilience_strategy",
+            "adaptation_plan",
+            "sectoral_adaptation_plan",
+            "disaster_risk_reduction_plan",
+            "heat_action_plan",
+            "coastal_adaptation_plan",
+            "nature_based_solutions_plan",
+            "capital_improvement_plan",
+            "capital_budget",
+            "other"
+          ],
+          "note": "Type of plan document. capital_improvement_plan and capital_budget added v0.2 to support ingestion of municipal CIPs whose line items are CapitalProjects."
+        },
+        {
+          "id": "plan_type_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when plan_type = other."
+        },
+        {
+          "id": "plan_title",
+          "label": "Plan Title",
+          "type": "string",
+          "required": true,
+          "definition": "Official title of the resilience plan document as published by the authoring organization.",
+          "notes": ""
+        },
+        {
+          "id": "adoption_year",
+          "label": "Adoption Year",
+          "type": "integer",
+          "required": true,
+          "definition": "Year in which the plan was officially adopted, approved, or published by the responsible authority.",
+          "notes": ""
+        },
+        {
+          "id": "planning_horizon_years",
+          "label": "Planning Horizon (Years)",
+          "type": "integer",
+          "required": false,
+          "definition": "Number of years from adoption that the plan is designed to cover, representing the intended implementation timeframe.",
+          "notes": ""
+        },
+        {
+          "id": "total_actions",
+          "label": "Total Actions",
+          "type": "integer",
+          "required": false,
+          "definition": "Total count of discrete actions, initiatives, or interventions specified within the plan document.",
+          "notes": ""
+        },
+        {
+          "id": "total_budget_mentioned",
+          "label": "Total Budget Mentioned",
+          "type": "string",
+          "required": false,
+          "definition": "Budget or financial resources mentioned in the plan, captured as free text due to varying formats and contexts.",
+          "notes": ""
+        },
+        {
+          "id": "monitoring_approach",
+          "label": "Monitoring Approach",
+          "type": "string",
+          "required": false,
+          "definition": "Description of how the plan's implementation and outcomes will be monitored, evaluated, or reported over time.",
+          "notes": ""
+        },
+        {
+          "id": "plan_uri",
+          "label": "Plan URI",
+          "type": "string",
+          "required": false,
+          "definition": "Unique resource identifier or persistent URL where the plan document can be accessed.",
+          "notes": ""
+        },
+        {
+          "id": "document_url",
+          "label": "Document URL",
+          "type": "string",
+          "required": false,
+          "definition": "Direct URL to the published PDF or web version of the plan document.",
+          "notes": ""
+        },
+        {
+          "id": "plan_status",
+          "label": "Plan Status",
+          "type": "string",
+          "required": false,
+          "definition": "Current status of the plan in its lifecycle (draft, adopted, active, completed, superseded).",
+          "notes": ""
+        },
+        {
+          "id": "review_cycle_years",
+          "type": "integer",
+          "required": false,
+          "note": "How frequently the plan is scheduled for review or update (e.g., 5 for a 5-year review cycle)."
+        }
+      ],
+      "vocabulary_bindings": [],
+      "notes": "Plans connect to goals (SETS), solutions (PRESCRIBES), actions (SPECIFIES), stakeholders (ENGAGES, ISSUES), locations (COVERS), hazards (ADDRESSES), urban systems (TARGETS), capital projects (SPECIFIES), and data sources (INFORMS).",
+      "extract_hint": "Look for named planning documents — e.g., 'Climate Action Plan', 'Resilience Strategy', 'Adaptation Plan', 'Heat Action Plan'. Also look for plan metadata: adoption year, planning horizon, budget, monitoring approach."
+    },
+    {
+      "id": "Action",
+      "label": "Action",
+      "definition": "A discrete initiative or intervention specified within a Plan — a specific, time-bound commitment with assigned timeline, budget, and implementation status. Distinct from Solution (which is the reusable intervention type): an Action is what a Plan commits to doing in a specific place and timeframe; a Solution is what that Action IS as a reusable class.",
+      "properties": [
+        {
+          "id": "action_name",
+          "type": "string",
+          "required": true,
+          "note": "Name or short description of the action as stated in the plan."
+        },
+        {
+          "id": "status",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "committed",
+            "in_planning",
+            "under_implementation",
+            "completed",
+            "cancelled"
+          ],
+          "note": "Implementation status. Aligned with C40, ICLEI, and GCoM action status vocabularies."
+        },
+        {
+          "id": "start_year",
+          "type": "integer",
+          "required": false
+        },
+        {
+          "id": "end_year",
+          "type": "integer",
+          "required": false
+        },
+        {
+          "id": "cost_usd",
+          "type": "number",
+          "required": false,
+          "note": "Budget allocated or estimated for this action in USD."
+        },
+        {
+          "id": "spatial_scale",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "city",
+            "district",
+            "neighborhood",
+            "site"
+          ],
+          "note": "Geographic scope of the action."
+        },
+        {
+          "id": "is_priority",
+          "type": "boolean",
+          "required": false,
+          "note": "Whether the plan flags this as a priority action."
+        },
+        {
+          "id": "financing_status",
+          "type": "enum",
+          "required": false,
+          "vocabulary": "enums",
+          "values": [
+            "fully_funded",
+            "partially_funded",
+            "seeking_full_funding",
+            "seeking_partial_funding",
+            "feasibility_stage",
+            "not_applicable"
+          ],
+          "note": "Funding status of the action. v0.2 — bound to enums.json#financing_status (previously orphaned)."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "financing_status"
+        }
+      ],
+      "notes": "CDP city action records are Action instances. Actions may optionally be linked to a Solution class via IMPLEMENTS, but many actions cannot be resolved to a known solution class. Actions connect directly to goals (PURSUES) and outcomes (RESULTS_IN) independent of solution resolution. v0.6 added three direct action-grain edges from CDP city-action fields: ADDRESSES Hazard (climate_hazard_s_that_action), TARGETS UrbanSystem (sectors_adaptation_action), and FUNDED_BY FinancingSource (funding_source_s) — none of which require the action to resolve to a Solution. A CapitalProject may REALIZES this Action when a CIP line item delivers on the commitment.",
+      "extract_hint": "Look for specific planned or committed initiatives with timelines or budgets — e.g., 'install 500 rain gardens by 2028', 'establish cooling centers in 12 districts', 'retrofit 1,000 buildings for flood resilience'. Distinct from general solution descriptions."
+    },
+    {
+      "id": "EnablingCondition",
+      "label": "Enabling Condition",
+      "definition": "A prerequisite condition (regulatory, financial, technical, social, institutional) required for successful solution deployment.",
+      "properties": [
+        {
+          "id": "condition",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "condition_type",
+          "type": "enum",
+          "required": true,
+          "values": [
+            "regulatory",
+            "financial",
+            "technical",
+            "social",
+            "institutional",
+            "political"
+          ]
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "condition_type"
+        }
+      ],
+      "notes": "Captures prerequisites for replicability. E.g., 'Requires enabling legislation for rainwater harvesting' or 'Needs upfront capital subsidy for low-income deployment'.",
+      "extract_hint": "Look for stated prerequisites, requirements, or conditions for success — e.g., 'requires building code reform', 'depends on community buy-in', 'needs dedicated funding stream'."
+    },
+    {
+      "id": "Barrier",
+      "label": "Barrier",
+      "definition": "An obstacle or constraint (regulatory, financial, technical, social, institutional, political) that impedes or prevents solution adoption. Can represent both systemic barriers and stakeholder-specific constraints.",
+      "properties": [
+        {
+          "id": "barrier",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "barrier_type",
+          "type": "enum",
+          "required": true,
+          "values": [
+            "regulatory",
+            "financial",
+            "technical",
+            "social",
+            "institutional",
+            "political"
+          ]
+        },
+        {
+          "id": "severity_score",
+          "type": "number",
+          "required": false,
+          "note": "Quantified severity (scale TBD)."
+        },
+        {
+          "id": "affected_stakeholder",
+          "type": "string",
+          "required": false,
+          "note": "Which actor or stakeholder group faces this barrier."
+        },
+        {
+          "id": "is_structural",
+          "type": "boolean",
+          "required": false,
+          "note": "Whether barrier is structural (systemic/deep-rooted) vs. contingent (addressable)."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "barrier_type"
+        }
+      ],
+      "notes": "Complements EnablingCondition. Barriers include a 'political' type not present in enabling conditions, reflecting the reality of implementation obstacles. Properties capture severity, affected stakeholders, and whether the barrier is structural (systemic) vs. contingent (addressable).",
+      "extract_hint": "Look for stated obstacles, challenges, or blockers — e.g., 'lack of political will', 'insufficient funding', 'regulatory uncertainty', 'community opposition', 'technical capacity gaps'."
+    },
+    {
+      "id": "FinancingSource",
+      "label": "Financing Source",
+      "definition": "A specific entity or funding source that provides capital for a solution (e.g., Green Climate Fund, World Bank, municipal budget).",
+      "properties": [
+        {
+          "id": "source_name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "source_type",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "municipal",
+            "national",
+            "international",
+            "private_sector",
+            "philanthropic",
+            "multilateral"
+          ]
+        },
+        {
+          "id": "amount_usd",
+          "type": "number",
+          "required": false
+        },
+        {
+          "id": "accreditation_modality",
+          "type": "enum",
+          "required": false,
+          "vocabulary": "enums",
+          "values": [
+            "national_implementing_entity",
+            "regional_implementing_entity",
+            "multilateral_implementing_entity",
+            "direct_access",
+            "enhanced_direct_access",
+            "pooled_facility",
+            "readiness_programme",
+            "not_applicable"
+          ],
+          "note": "AF/GCF access modality — captures the institutional arrangement through which the source delivers capital. Use when the source is part of the Adaptation Fund or Green Climate Fund architecture; use 'not_applicable' for sources outside this framework. Distinct from source_type (broad funder category) and from FinancialInstrument.instrument_type (structural form of the capital itself)."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "accreditation_modality"
+        }
+      ],
+      "notes": "Can be named entities (Green Climate Fund) or generic types (municipal budget). Links to FinancialInstrument via CHANNELS_THROUGH to capture 'who funds via what mechanism'. The accreditation_modality property (added v0.1.1) captures AF/GCF-specific access arrangements (NIEs, direct access, pooled facilities) without conflating them with the operational Mechanism vocabulary, which describes how a Solution physically achieves adaptation effect.",
+      "extract_hint": "Look for named funders, funding programs, or budget sources — e.g., 'Green Climate Fund', 'World Bank', 'municipal capital budget', 'FEMA hazard mitigation grants'. For AF/GCF references, also extract the access modality (NIE, MIE, direct access, etc.)."
+    },
+    {
+      "id": "FinancialInstrument",
+      "label": "Financial Instrument",
+      "definition": "A specific financial mechanism used to fund a solution or capital project (e.g., green bond, general obligation bond, revenue bond, sustainability-linked loan, resilience bond, blended finance, grant, direct allocation).",
+      "properties": [
+        {
+          "id": "instrument_type",
+          "type": "enum",
+          "required": true,
+          "values": [
+            "green_bond",
+            "general_obligation_bond",
+            "revenue_bond",
+            "tax_increment_financing",
+            "special_assessment",
+            "sustainability_linked_loan",
+            "climate_bond",
+            "resilience_bond",
+            "blended_finance",
+            "revolving_fund",
+            "grant",
+            "federal_cost_share",
+            "state_cost_share",
+            "municipal_capital_appropriation",
+            "ratepayer_funded",
+            "direct_allocation",
+            "outcome_bond",
+            "other"
+          ],
+          "note": "Type of financial instrument. v0.2 added US municipal CIP terms; v0.3 added outcome_bond (pay-for-success / environmental impact bond — repayment contingent on measured outcomes, see CONTINGENT_ON relationship)."
+        },
+        {
+          "id": "instrument_type_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when instrument_type = other."
+        },
+        {
+          "id": "amount_usd",
+          "type": "number",
+          "required": false
+        },
+        {
+          "id": "principal_amount_usd",
+          "type": "number",
+          "required": false,
+          "note": "Principal amount of debt instrument (bond face value, loan principal). v0.2."
+        },
+        {
+          "id": "interest_rate",
+          "type": "number",
+          "required": false,
+          "note": "Annual interest rate as decimal (e.g., 0.045 for 4.5%). v0.2."
+        },
+        {
+          "id": "loan_term_years",
+          "type": "integer",
+          "required": false,
+          "note": "Term of the debt in years. v0.2."
+        },
+        {
+          "id": "annual_debt_service_usd",
+          "type": "number",
+          "required": false,
+          "note": "Annual debt-service payment in USD. v0.2 — needed for budget-impact analysis (e.g., a $100M 30-year loan at 5% has roughly $6.5M/yr debt service)."
+        },
+        {
+          "id": "issuance_year",
+          "type": "integer",
+          "required": false,
+          "note": "Year the instrument was issued. v0.2."
+        },
+        {
+          "id": "maturity_year",
+          "type": "integer",
+          "required": false,
+          "note": "Year the instrument matures. v0.2."
+        },
+        {
+          "id": "issuer",
+          "type": "string",
+          "required": false,
+          "note": "Name of the issuing entity (e.g., 'City of Miami Beach', 'NYC Municipal Water Finance Authority'). v0.2."
+        },
+        {
+          "id": "credit_rating",
+          "type": "string",
+          "required": false,
+          "note": "Credit rating of the instrument or issuer (e.g., 'Aa2', 'AA-'). v0.2."
+        },
+        {
+          "id": "description",
+          "type": "string",
+          "required": false
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "instrument_type",
+          "note": "CDP project finance vocabulary, extended in v0.2 with US municipal CIP terms"
+        }
+      ],
+      "notes": "v0.2 added debt-service properties (principal, interest rate, term, annual_debt_service, maturity, issuer, credit_rating) for amortization and budget-impact analysis. v0.3 added outcome_bond type and CONTINGENT_ON edge to Outcome for pay-for-success instruments.",
+      "extract_hint": "Look for named financing mechanisms — e.g., 'general obligation bond', 'revenue bond backed by water rates', 'green bond', 'revolving loan fund', 'blended finance facility', 'grant from federal government', 'special assessment district'. For debt instruments, capture principal, term, interest rate, and annual debt service when stated."
+    },
+    {
+      "id": "CapitalProject",
+      "label": "Capital Project",
+      "definition": "A line item in a capital budget or Capital Improvement Plan (CIP): a discrete, named, multi-year capital expenditure with a project identifier, scope, cost profile, and financing structure. May or may not be climate-relevant — climate relevance is inferred via REALIZES (Action) and through Solution-linked paths.",
+      "properties": [
+        {
+          "id": "project_id",
+          "type": "string",
+          "required": true,
+          "note": "Native budget-document identifier (e.g., '23-WTR-015', 'CIP-2026-042'). Critical for cross-referencing back to the source budget."
+        },
+        {
+          "id": "project_name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "description",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "asset_class",
+          "type": "enum",
+          "required": false,
+          "vocabulary": "enums",
+          "values": [
+            "water",
+            "wastewater",
+            "stormwater",
+            "transportation",
+            "parks_open_space",
+            "public_safety",
+            "public_buildings",
+            "housing",
+            "schools",
+            "energy",
+            "solid_waste",
+            "telecom",
+            "coastal_protection",
+            "other"
+          ],
+          "note": "Asset class of the capital project. Captured as a property rather than a direct OPERATES_ON UrbanSystem edge — when the project's solution class is resolvable via REALIZES Action → IMPLEMENTS Solution → OPERATES_ON UrbanSystem, that path is authoritative; asset_class is the local annotation from the budget document itself."
+        },
+        {
+          "id": "asset_class_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when asset_class = other."
+        },
+        {
+          "id": "total_capex_usd",
+          "type": "number",
+          "required": false,
+          "note": "Total capital expenditure in USD across the full project lifecycle."
+        },
+        {
+          "id": "annual_opex_usd",
+          "type": "number",
+          "required": false,
+          "note": "Estimated recurring operations and maintenance cost in USD per year."
+        },
+        {
+          "id": "asset_life_years",
+          "type": "integer",
+          "required": false,
+          "note": "Design life of the asset in years. Useful for amortization sanity checks (debt term should not exceed asset life)."
+        },
+        {
+          "id": "start_year",
+          "type": "integer",
+          "required": false
+        },
+        {
+          "id": "completion_year",
+          "type": "integer",
+          "required": false
+        },
+        {
+          "id": "construction_phase",
+          "type": "enum",
+          "required": false,
+          "vocabulary": "enums",
+          "values": [
+            "proposed",
+            "design",
+            "permitting",
+            "under_construction",
+            "commissioned",
+            "decommissioned"
+          ],
+          "note": "Current lifecycle phase of the project. Distinct from Action.status (committed/in_planning/under_implementation/completed/cancelled) — capital projects have a richer construction lifecycle independent of plan-commitment status."
+        },
+        {
+          "id": "funding_year_breakdown",
+          "type": "string",
+          "required": false,
+          "note": "Free-text year-by-year capital outlay schedule (e.g., '$10M FY26, $30M FY27, $20M FY28'). Captured as free text for now — formalize to structured array if corpus warrants."
+        },
+        {
+          "id": "financing_status",
+          "type": "enum",
+          "required": false,
+          "vocabulary": "enums",
+          "values": [
+            "fully_funded",
+            "partially_funded",
+            "seeking_full_funding",
+            "seeking_partial_funding",
+            "feasibility_stage",
+            "not_applicable"
+          ],
+          "note": "Funding status of the project. Bound to enums.json#financing_status (previously orphaned; bound in v0.2)."
+        },
+        {
+          "id": "is_climate_relevant",
+          "type": "boolean",
+          "required": false,
+          "note": "Analytical flag set after ingestion to mark whether the project reduces climate risk or produces climate-relevant co-benefits. Default unset means unanalyzed. Not an extraction-time field."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "enums",
+          "field": "asset_class"
+        },
+        {
+          "vocab": "enums",
+          "field": "construction_phase"
+        },
+        {
+          "vocab": "enums",
+          "field": "financing_status"
+        }
+      ],
+      "notes": "Added v0.2 (Salkin/RCC resilience finance brief). Distinct from Action (climate-plan commitment): CapitalProject is sourced from budget documents (CIP, OpenGov) and tested for climate relevance post-ingestion. Edges reachable via multi-hop (MITIGATES, REDUCES_EXPOSURE, PURSUES) are deliberately omitted to keep the schema lean. v0.6 added TARGETS UrbanSystem (system domain from CDP project_area, promoting it from the asset_class property to a queryable edge) and FUNDED_BY FinancingSource (landing the edge referenced since v0.2).",
+      "extract_hint": "Look for budget-document line items — e.g., a CIP entry like 'Project 23-WTR-015: Watershed Drainage Improvements, $50M total, FY26–FY30, water utility, revenue-bond financed', or 'Capital Project: South Beach Resilience Wall, $120M, federal cost-share + GO bond'. Capture project_id whenever stated. Distinct from action descriptions in climate plans (those are Actions); when a CIP entry can be tied to a climate-plan action, link via REALIZES."
+    },
+    {
+      "id": "Supplier",
+      "label": "Supplier",
+      "definition": "A vendor, manufacturer, or service provider that supplies technology, components, or services for a solution.",
+      "properties": [
+        {
+          "id": "supplier_name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "id": "role",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "manufacturer",
+            "system_integrator",
+            "service_provider",
+            "consultant"
+          ]
+        }
+      ],
+      "vocabulary_bindings": [],
+      "notes": "Captures the supply chain layer. Enables vendor analysis and technology provider tracking.",
+      "extract_hint": "Look for named companies, vendors, or service providers — e.g., 'Siemens provided the sensor network', 'installed by XYZ Engineering', 'technology from ABC Corp'."
+    },
+    {
+      "id": "Vulnerability",
+      "label": "Vulnerability",
+      "definition": "A climate vulnerability characterized by exposure, sensitivity, and adaptive capacity, following the IPCC AR6 framework where vulnerability = f(exposure, sensitivity, adaptive capacity). Represents what adaptation solutions aim to reduce.",
+      "properties": [
+        {
+          "id": "vuln_type",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "economic_inequality",
+            "poverty",
+            "structural_racism",
+            "food_insecurity",
+            "gender_inequality",
+            "housing_insecurity",
+            "poor_adaptive_capacity",
+            "low_social_cohesion",
+            "compound_social_vulnerability",
+            "other"
+          ],
+          "note": "Type of social vulnerability. Drawn from the RCC vulnerability crosswalk (IPCC AR6, UNDRR Sendai Framework, EDF equity framework)."
+        },
+        {
+          "id": "vuln_type_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when vuln_type = other."
+        },
+        {
+          "id": "exposure_score",
+          "type": "number",
+          "required": false,
+          "note": "Quantified exposure level (scale TBD)."
+        },
+        {
+          "id": "sensitivity_score",
+          "type": "number",
+          "required": false,
+          "note": "Quantified sensitivity level (scale TBD)."
+        },
+        {
+          "id": "adaptive_capacity_score",
+          "type": "number",
+          "required": false,
+          "note": "Quantified adaptive capacity level (scale TBD)."
+        },
+        {
+          "id": "affected_group",
+          "type": "array<string>",
+          "required": false,
+          "vocabulary": "vulnerable-populations",
+          "note": "Population group(s) experiencing this vulnerability. Bound to vulnerable-populations vocabulary."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "vulnerable-populations",
+          "field": "affected_group"
+        }
+      ],
+      "notes": "Aligns with IPCC AR6 and UNDRR vulnerability frameworks. Planners measure success by vulnerability reduction. Vulnerability is both hazard-linked (via ExposureUnit) and socially constructed (via UrbanSystem SHAPES Vulnerability).",
+      "extract_hint": "Look for descriptions of who or what is vulnerable and why — e.g., 'low-income neighborhoods vulnerable to heat', 'aging infrastructure sensitive to flooding', 'limited adaptive capacity in informal settlements'."
+    },
+    {
+      "id": "ExposureUnit",
+      "label": "Exposure Unit",
+      "definition": "A population or asset exposed to climate hazards. Aligns with the UNDRR Sendai Framework for disaster risk reduction. Links hazards to vulnerabilities through exposure pathways (Risk = Hazard x Exposure x Vulnerability).",
+      "properties": [
+        {
+          "id": "population_count",
+          "type": "number",
+          "required": false,
+          "note": "Number of people in exposure unit."
+        },
+        {
+          "id": "asset_value",
+          "type": "number",
+          "required": false,
+          "note": "Economic value of exposed assets (USD)."
+        },
+        {
+          "id": "vulnerable_ratio",
+          "type": "number",
+          "required": false,
+          "note": "Proportion of population that is vulnerable (0-1 scale)."
+        },
+        {
+          "id": "social_capital_index",
+          "type": "number",
+          "required": false,
+          "note": "Measure of social cohesion/networks (scale TBD)."
+        },
+        {
+          "id": "affected_group",
+          "type": "array<string>",
+          "required": false,
+          "vocabulary": "vulnerable-populations",
+          "note": "Specific vulnerable population group(s) present in this exposure unit. Bound to vulnerable-populations vocabulary."
+        }
+      ],
+      "vocabulary_bindings": [
+        {
+          "vocab": "vulnerable-populations",
+          "field": "affected_group"
+        }
+      ],
+      "notes": "Connects hazards to vulnerabilities: Hazard EXPOSES ExposureUnit, ExposureUnit EXPERIENCES Vulnerability. Enables quantified exposure analysis in planning contexts.",
+      "extract_hint": "Look for descriptions of exposed populations or assets — e.g., '50,000 residents in the floodplain', '$2B in coastal property', 'critical hospital infrastructure in the storm surge zone'."
+    },
+    {
+      "id": "PlanningData",
+      "label": "Planning Data",
+      "definition": "A data source referenced or cited as informing a climate adaptation or resilience plan — e.g., downscaled climate projections, hazard maps, vulnerability assessments, demographic datasets.",
+      "properties": [
+        {
+          "id": "data_name",
+          "type": "string",
+          "required": true,
+          "note": "Name or title of the data source."
+        },
+        {
+          "id": "data_type",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "hazard_map",
+            "vulnerability_assessment",
+            "climate_projection",
+            "demographic_dataset",
+            "land_use_map",
+            "monitoring_report",
+            "other"
+          ],
+          "note": "Category of planning data."
+        },
+        {
+          "id": "data_type_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when data_type = other."
+        },
+        {
+          "id": "data_source",
+          "type": "string",
+          "required": false,
+          "note": "Organization or agency that produced this data (e.g., 'NOAA', 'city planning department')."
+        },
+        {
+          "id": "data_source_url",
+          "type": "string",
+          "required": false,
+          "note": "URL to the data source or dataset."
+        },
+        {
+          "id": "publication_year",
+          "type": "integer",
+          "required": false
+        },
+        {
+          "id": "spatial_coverage",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "city",
+            "regional",
+            "national",
+            "global",
+            "other"
+          ],
+          "note": "Geographic scope of the dataset."
+        },
+        {
+          "id": "spatial_coverage_other_description",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "temporal_coverage",
+          "type": "string",
+          "required": false,
+          "note": "Time period the data covers (e.g., '1990-2020', '2050 projection'). Free-text."
+        }
+      ],
+      "vocabulary_bindings": [],
+      "notes": "Catalogs data inputs to planning processes. Can link to Solutions that generate data (e.g., a climate hazard model solution GENERATES PlanningData that INFORMS a Plan).",
+      "extract_hint": "Look for referenced datasets, models, assessments, or studies that informed plan development — e.g., 'based on NOAA climate projections', 'informed by city vulnerability assessment', 'uses downscaled RCP 8.5 scenario data'."
+    },
+    {
+      "id": "GovernanceStructure",
+      "label": "Governance Structure",
+      "definition": "A formal body or institutional arrangement that governs, oversees, or coordinates climate adaptation planning — including interagency bodies, public agencies, advisory committees, and public-private partnerships.",
+      "properties": [
+        {
+          "id": "structure_type",
+          "type": "enum",
+          "required": true,
+          "values": [
+            "interagency_body",
+            "public_agency",
+            "advisory_committee",
+            "task_force",
+            "public_private_partnership",
+            "other"
+          ],
+          "note": "Type of governance structure."
+        },
+        {
+          "id": "structure_type_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when structure_type = other."
+        },
+        {
+          "id": "authority_level",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "advisory",
+            "regulatory",
+            "operational",
+            "other"
+          ],
+          "note": "Level of formal authority: advisory (recommends), regulatory (enforces), operational (implements)."
+        },
+        {
+          "id": "authority_level_other_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description when authority_level = other."
+        },
+        {
+          "id": "mandate_description",
+          "type": "string",
+          "required": false,
+          "note": "Free-text description of the body's mandate, remit, or legal basis."
+        }
+      ],
+      "vocabulary_bindings": [],
+      "notes": "Captures the formal governance layer around adaptation plans. Distinct from Stakeholder (which can be any actor); GovernanceStructure represents a body with a defined mandate over planning or coordination. GOVERNS links it to Plans; MEMBER_OF links Stakeholders to it.",
+      "extract_hint": "Look for named governance bodies, committees, or institutional arrangements — e.g., 'Climate Resilience Task Force', 'Office of Emergency Management', 'City-County Climate Coordination Council', 'Climate Adaptation Advisory Panel'."
+    }
+  ],
+  "relationships": [
+    {
+      "id": "MITIGATES",
+      "label": "mitigates",
+      "source": "Solution",
+      "target": "Hazard",
+      "definition": "The solution is designed to reduce the impact, likelihood, or severity of this climate hazard.",
+      "properties": [
+        {
+          "id": "is_primary",
+          "type": "boolean",
+          "required": false,
+          "note": "True if this is the primary hazard addressed."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Core relationship in the solutions domain. is_primary distinguishes the primary hazard from co-addressed hazards.",
+      "extract_hint": "Look for claims that a solution addresses, reduces, or protects against a specific hazard — e.g., 'designed to mitigate urban flooding', 'reduces heat island effect'."
+    },
+    {
+      "id": "OPERATES_ON",
+      "label": "operates on",
+      "source": "Solution",
+      "target": "UrbanSystem",
+      "definition": "The solution is deployed within, protects, or modifies this urban system or infrastructure component.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Enables interdependency queries (e.g., 'Which solutions protect substations?'). Multiple systems can be affected by one solution.",
+      "extract_hint": "Look for which infrastructure or urban systems a solution acts upon — e.g., 'installed on the stormwater network', 'protects the electrical grid', 'integrated into public transit'."
+    },
+    {
+      "id": "DEPENDS_ON",
+      "label": "depends on",
+      "source": "Solution",
+      "target": "Solution",
+      "definition": "The source solution requires the target solution to be in place or concurrently deployed to function. Captures technology-stack dependencies, data-platform prerequisites, physical/operational coupling, and programmatic prerequisites.",
+      "properties": [
+        {
+          "id": "dependency_type",
+          "type": "enum",
+          "values": [
+            "requires_data_from",
+            "runs_on_platform",
+            "integrates_with",
+            "physically_coupled_to",
+            "programmatically_requires"
+          ],
+          "required": false,
+          "note": "Nature of the dependency: requires_data_from, runs_on_platform, integrates_with, physically_coupled_to, or programmatically_requires."
+        },
+        {
+          "id": "is_critical",
+          "type": "boolean",
+          "required": false,
+          "note": "True if the target solution must be operational for the source to function (hard dependency). False if the target enhances but is not strictly required (soft dependency)."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Self-referential (Solution → Solution). Covers both tech dependencies (sensor network requires data platform) and non-tech prerequisites (cooling centers require heat early warning). Extraction must guard against conflating with SUPPLIES (vendor relationship).",
+      "extract_hint": "Look for dependency language between solutions — e.g., 'requires real-time data from the sensor network', 'runs on the city's IoT platform', 'activated when early warning system triggers'."
+    },
+    {
+      "id": "WORKS_BY",
+      "label": "works by",
+      "source": "Solution",
+      "target": "Mechanism",
+      "definition": "The solution employs this functional mechanism to achieve its adaptation effect.",
+      "properties": [
+        {
+          "id": "is_primary",
+          "type": "boolean",
+          "required": false,
+          "note": "True for the primary mechanism, false for secondary mechanisms."
+        },
+        {
+          "id": "technical_components",
+          "type": "array<object>",
+          "required": false,
+          "note": "Specific technical components implementing this mechanism."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Reads naturally: 'bioswale works by absorption.' Technical components stored as relationship property.",
+      "extract_hint": "Look for descriptions of HOW a solution functions — e.g., 'works by absorbing excess rainfall', 'operates through real-time monitoring and automated alerts'."
+    },
+    {
+      "id": "IMPLEMENTED_IN",
+      "label": "implemented in",
+      "source": "Solution",
+      "target": "Jurisdiction",
+      "definition": "The solution is deployed, operational, or proposed in this location.",
+      "properties": [
+        {
+          "id": "deployment_context",
+          "type": "string",
+          "required": false,
+          "note": "Local adaptation notes (e.g., 'adapted to Nordic climate')."
+        },
+        {
+          "id": "zone_type",
+          "type": "string",
+          "required": false,
+          "note": "Spatial zone within city (e.g., 'downtown', 'waterfront', 'residential district')."
+        },
+        {
+          "id": "area_km2",
+          "type": "number",
+          "required": false,
+          "note": "Area covered by deployment in square kilometers."
+        },
+        {
+          "id": "population_density",
+          "type": "number",
+          "required": false,
+          "note": "Population density in the deployment zone (people per km²)."
+        },
+        {
+          "id": "land_use_type",
+          "type": "string",
+          "required": false,
+          "note": "Land use classification (e.g., 'commercial', 'residential', 'industrial', 'mixed-use')."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Many-to-many enables replication tracking. Same solution can appear in multiple locations. Spatial properties enable sub-city targeting.",
+      "extract_hint": "Look for where a solution is deployed — e.g., 'implemented in Rotterdam', 'piloted in three districts of Mumbai', 'deployed along the waterfront corridor'."
+    },
+    {
+      "id": "IMPLEMENTED_BY",
+      "label": "implemented by",
+      "source": "Solution",
+      "target": "Stakeholder",
+      "definition": "The solution is implemented or operated by this stakeholder.",
+      "properties": [
+        {
+          "id": "role",
+          "type": "string",
+          "required": false,
+          "note": "Specific role (e.g., 'lead implementer', 'technical partner')."
+        },
+        {
+          "id": "is_lead",
+          "type": "boolean",
+          "required": false,
+          "note": "True if this is the primary implementing actor."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many",
+      "notes": "Captures primary responsibility for solution implementation. is_lead distinguishes the lead implementer from supporting actors (see also PARTICIPATES_IN for non-lead involvement).",
+      "extract_hint": "Look for who is responsible for implementing a solution — e.g., 'led by the city water authority', 'implemented by the parks department', 'operated by a public-private partnership'."
+    },
+    {
+      "id": "CONTRIBUTES_TO",
+      "label": "contributes to",
+      "source": "Solution",
+      "target": "ResilienceGoal",
+      "definition": "The solution advances or supports achieving this resilience goal. Claim-based: what the solution class is known or believed to achieve. Distinct from DEMONSTRATES_PROGRESS_ON (measured evidence) and TARGETS_GOAL (action-level planning intent).",
+      "properties": [
+        {
+          "id": "contribution_description",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Links solutions to the CRF 2024 framework at the solution-class level.",
+      "extract_hint": "Look for claims linking a solution type to resilience outcomes — e.g., 'green roofs contribute to improved public health', 'early warning systems support continuity of critical services'."
+    },
+    {
+      "id": "SETS",
+      "label": "sets",
+      "source": "Plan",
+      "target": "ResilienceGoal",
+      "definition": "The plan establishes this resilience goal as a target or objective. Forward-looking: what the plan aims to achieve.",
+      "properties": [
+        {
+          "id": "target_year",
+          "type": "integer",
+          "required": false,
+          "note": "Target year for achieving this goal."
+        },
+        {
+          "id": "priority_level",
+          "type": "enum",
+          "values": [
+            "high",
+            "medium",
+            "low"
+          ],
+          "required": false,
+          "note": "Priority assigned to this goal in the plan."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Enables gap analysis: which goals are set in plans vs. which goals have deployed solutions vs. which goals have measured outcomes.",
+      "extract_hint": "Look for goal-setting language in plans — e.g., 'the plan targets improved access to affordable housing', 'aims to achieve zero climate-related deaths by 2035'."
+    },
+    {
+      "id": "DEMONSTRATES_PROGRESS_ON",
+      "label": "demonstrates progress on",
+      "source": "Outcome",
+      "target": "ResilienceGoal",
+      "definition": "The measured outcome provides evidence of progress toward achieving this resilience goal. Evidence-based: the strongest epistemic tier linking outcomes to goals.",
+      "properties": [
+        {
+          "id": "evidence_level",
+          "type": "enum",
+          "values": [
+            "anecdotal",
+            "measured",
+            "rigorously_evaluated"
+          ],
+          "required": false,
+          "note": "Strength of evidence: anecdotal, measured, or rigorously_evaluated."
+        },
+        {
+          "id": "achieved",
+          "type": "boolean",
+          "required": false,
+          "note": "Whether the resilience goal has been achieved based on this outcome evidence."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Provides the measured evidence chain: Solution/Action PRODUCES/RESULTS_IN Outcome, Outcome DEMONSTRATES_PROGRESS_ON ResilienceGoal. Complements CONTRIBUTES_TO (claim-based) and TARGETS_GOAL (planning intent).",
+      "extract_hint": "Look for measured results tied to resilience objectives — e.g., 'flood reduction outcomes demonstrate progress on infrastructure resilience goals', 'mortality data evidences improved public health outcomes'."
+    },
+    {
+      "id": "PRODUCES",
+      "label": "produces",
+      "source": "Solution",
+      "target": "Outcome",
+      "definition": "The solution generates this outcome (effectiveness indicator, co-benefit, or failure mode). Captures what a solution class is known to produce at the general level.",
+      "properties": [
+        {
+          "id": "outcome_type",
+          "type": "enum",
+          "required": true,
+          "note": "Category of outcome. Values from outcome_type in enums (effectiveness_indicator, co_benefit, failure_mode, maladaptation, other).",
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "outcome_type"
+          }
+        },
+        {
+          "id": "evidence_level",
+          "type": "enum",
+          "required": false,
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "evidence_level"
+          }
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "one-to-many",
+      "notes": "Aggregates effectiveness, co-benefits, and failure modes. The outcome_type property differentiates. For instance-level outcomes from specific deployments, see RESULTS_IN (Action → Outcome).",
+      "extract_hint": "Look for documented results of a solution type — e.g., 'green roofs typically reduce stormwater runoff by 30-50%', 'permeable pavement has been shown to reduce urban heat island effect as a co-benefit', 'system failures reported during extreme events'."
+    },
+    {
+      "id": "RESULTS_IN",
+      "label": "results in",
+      "source": "Action",
+      "target": "Outcome",
+      "definition": "The action resulted in this outcome (effectiveness indicator, co-benefit, or failure mode). Instance-level counterpart to PRODUCES: captures what a specific deployment actually produced.",
+      "properties": [
+        {
+          "id": "outcome_type",
+          "type": "enum",
+          "required": true,
+          "note": "Category of outcome. Values from outcome_type in enums (effectiveness_indicator, co_benefit, failure_mode, maladaptation, other).",
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "outcome_type"
+          }
+        },
+        {
+          "id": "evidence_level",
+          "type": "enum",
+          "required": false,
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "evidence_level"
+          }
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "one-to-many",
+      "notes": "Distinct from PRODUCES (Solution → Outcome) which captures class-level knowledge. RESULTS_IN captures what a specific action in a specific place actually produced — including failure modes. Enables the evidence chain: Action RESULTS_IN Outcome, Outcome DEMONSTRATES_PROGRESS_ON ResilienceGoal.",
+      "extract_hint": "Look for specific, located results — e.g., 'the rain garden program in District 5 reduced local flooding by 40%', 'the cooling center initiative failed to reach elderly residents during the 2025 heat wave'."
+    },
+    {
+      "id": "MEASURED_BY",
+      "label": "measured by",
+      "source": "Outcome",
+      "target": "Indicator",
+      "definition": "The outcome is quantified using this specific metric or indicator.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "one-to-many",
+      "notes": "Indicators are children of effectiveness outcomes. Not all outcomes have indicators (co-benefits and failure modes typically don't).",
+      "extract_hint": "Look for specific metrics attached to outcomes — e.g., 'measured by flood events per year', 'tracked via PM2.5 concentration', 'quantified as dollars of avoided damage'."
+    },
+    {
+      "id": "REQUIRES",
+      "label": "requires",
+      "source": "Solution",
+      "target": "EnablingCondition",
+      "definition": "The solution requires this condition to be met for successful deployment or operation.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Captures prerequisites for replicability. Important for understanding what must be in place before a solution can work in a new context.",
+      "extract_hint": "Look for stated requirements — e.g., 'requires enabling legislation', 'depends on dedicated maintenance budget', 'needs technical capacity in the water utility'."
+    },
+    {
+      "id": "FACES",
+      "label": "faces",
+      "source": "Action",
+      "target": "Barrier",
+      "definition": "The plan action encounters this barrier during implementation. The fuzziness of 'faces' suits actions, which are less specific than solutions — an action facing a barrier may work around it or adapt without necessarily removing it.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Captures implementation-level barriers encountered by specific plan actions. Distinct from BLOCKS (Barrier → Solution), which signals that a barrier must be actively removed for a solution to proceed.",
+      "extract_hint": "Look for obstacles encountered in specific plan commitments — e.g., 'the green roof action faces funding constraints', 'cooling center installation is hindered by land availability'."
+    },
+    {
+      "id": "PRESCRIBES",
+      "label": "prescribes",
+      "source": "Plan",
+      "target": "Solution",
+      "definition": "The plan specifies or calls for implementation of this solution.",
+      "properties": [
+        {
+          "id": "implementation_stage",
+          "type": "enum",
+          "values": [
+            "committed",
+            "in_planning",
+            "under_implementation",
+            "completed"
+          ],
+          "required": false,
+          "note": "Stage of implementation: committed, in_planning, under_implementation, or completed. Aligned with C40, ICLEI, and GCoM vocabularies."
+        },
+        {
+          "id": "implementation_timeline",
+          "type": "string",
+          "required": false,
+          "note": "Expected timeline from plan (e.g., 'by 2030', 'Phase 1')."
+        },
+        {
+          "id": "is_priority",
+          "type": "boolean",
+          "required": false,
+          "note": "Whether solution is flagged as a priority action."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Plans prescribe specific solutions (what to implement). Distinct from CONTAINS_ACTION (specific time-bound commitments) — PRESCRIBES links to solution classes.",
+      "extract_hint": "Look for plan language mandating or recommending specific solution types — e.g., 'the plan calls for expanded green infrastructure', 'recommends deployment of flood early warning systems'."
+    },
+    {
+      "id": "USES_INSTRUMENT",
+      "label": "uses financial instrument",
+      "source": "Solution",
+      "target": "FinancialInstrument",
+      "definition": "The solution is financed using this financial mechanism or instrument.",
+      "properties": [
+        {
+          "id": "amount_usd",
+          "type": "number",
+          "required": false
+        },
+        {
+          "id": "description",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Captures the 'how' of financing. The full financing path: FinancingSource CHANNELS_THROUGH FinancialInstrument, Solution USES_INSTRUMENT FinancialInstrument.",
+      "extract_hint": "Look for financing mechanisms tied to solutions — e.g., 'funded through a green bond', 'financed via revolving loan fund', 'supported by blended finance facility'."
+    },
+    {
+      "id": "SUPPLIES",
+      "label": "supplies",
+      "source": "Supplier",
+      "target": "Solution",
+      "definition": "The supplier provides technology, components, or services for this solution.",
+      "properties": [
+        {
+          "id": "component_refs",
+          "type": "array<string>",
+          "required": false,
+          "note": "References to specific technical components this supplier provides."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Captures the supply chain layer. component_refs link suppliers to specific technical components.",
+      "extract_hint": "Look for vendor/supplier relationships — e.g., 'sensors provided by Siemens', 'engineering services from AECOM', 'software platform supplied by IBM'."
+    },
+    {
+      "id": "REDUCES",
+      "label": "reduces",
+      "source": "Solution",
+      "target": "Vulnerability",
+      "definition": "The solution decreases or mitigates this vulnerability by improving adaptive capacity, reducing exposure, or decreasing sensitivity. Aligns with the IPCC AR6 vulnerability framework.",
+      "properties": [
+        {
+          "id": "mechanism_of_reduction",
+          "type": "enum",
+          "values": [
+            "reduces_exposure",
+            "reduces_sensitivity",
+            "increases_adaptive_capacity",
+            "multi_pathway"
+          ],
+          "required": false,
+          "note": "How the solution achieves vulnerability reduction per IPCC AR6: reduces_exposure, reduces_sensitivity, increases_adaptive_capacity, or multi_pathway."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Key planning outcome — planners measure success by vulnerability reduction. The mechanism_of_reduction property maps to IPCC AR6 vulnerability components.",
+      "extract_hint": "Look for claims about vulnerability reduction — e.g., 'reduces flood vulnerability of low-lying neighborhoods', 'improves adaptive capacity of informal settlements', 'decreases sensitivity of aging water infrastructure'."
+    },
+    {
+      "id": "PARTICIPATES_IN",
+      "label": "participates in",
+      "source": "Stakeholder",
+      "target": "Solution",
+      "definition": "This stakeholder is involved in or contributes to the solution without being the primary implementer. Complements IMPLEMENTED_BY (primary responsibility).",
+      "properties": [
+        {
+          "id": "participation_role",
+          "type": "string",
+          "required": false,
+          "note": "Specific role (e.g., 'technical advisor', 'community representative', 'funder')."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Captures non-lead participation. Enables mapping of the full stakeholder ecosystem around a solution.",
+      "extract_hint": "Look for supporting actor roles — e.g., 'community groups participated in design', 'university provided technical advisory', 'NGO facilitated community engagement'."
+    },
+    {
+      "id": "ISSUES",
+      "label": "issues",
+      "source": "Stakeholder",
+      "target": "Plan",
+      "definition": "The stakeholder creates, publishes, or officially issues a Plan. Typically a municipal government or regional authority.",
+      "properties": [
+        {
+          "id": "adoption_status",
+          "type": "enum",
+          "values": [
+            "draft",
+            "adopted",
+            "revised"
+          ],
+          "required": false,
+          "note": "Status of plan when issued: draft, adopted, or revised."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-one",
+      "notes": "Captures plan authorship and institutional ownership. Can have multiple issuers for regional or multi-jurisdictional plans.",
+      "extract_hint": "Look for plan authorship — e.g., 'published by the City of Rotterdam', 'issued by the Metropolitan Planning Commission', 'jointly developed by three municipalities'."
+    },
+    {
+      "id": "EXPOSES",
+      "label": "exposes",
+      "source": "Hazard",
+      "target": "ExposureUnit",
+      "definition": "The climate hazard exposes this population or asset to risk. Creates the exposure pathway in the UNDRR/Sendai risk framework (Risk = Hazard x Exposure x Vulnerability).",
+      "properties": [
+        {
+          "id": "impact_severity",
+          "type": "enum",
+          "values": [
+            "low",
+            "moderate",
+            "high",
+            "severe"
+          ],
+          "required": false,
+          "note": "Severity of exposure impact: low, moderate, high, or severe."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Captures the exposure component of the UNDRR risk equation.",
+      "extract_hint": "Look for exposure claims — e.g., 'coastal flooding exposes 50,000 residents', 'extreme heat threatens outdoor workers', 'sea level rise puts $2B in property at risk'."
+    },
+    {
+      "id": "EXPERIENCES",
+      "label": "experiences",
+      "source": "ExposureUnit",
+      "target": "Vulnerability",
+      "definition": "The exposure unit experiences or manifests this vulnerability. Completes the UNDRR risk chain: hazards expose units, units experience vulnerability.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Completes the risk pathway: Hazard EXPOSES ExposureUnit, ExposureUnit EXPERIENCES Vulnerability, Solution REDUCES Vulnerability.",
+      "extract_hint": "Look for vulnerability descriptions tied to specific populations or assets — e.g., 'low-income residents experience heightened heat vulnerability', 'aging infrastructure shows sensitivity to flood damage'."
+    },
+    {
+      "id": "CHANNELS_THROUGH",
+      "label": "channels through",
+      "source": "FinancingSource",
+      "target": "FinancialInstrument",
+      "definition": "The financing source channels capital through this financial instrument. Captures the 'who funds via what mechanism' linkage (e.g., 'World Bank channels funding through a green bond').",
+      "properties": [
+        {
+          "id": "amount_usd",
+          "type": "number",
+          "required": false,
+          "note": "Amount this source contributes to capitalizing the instrument (pool contribution or grant award)"
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Links FinancingSource (who provides money) to FinancialInstrument (how money is structured). Multiple sources can channel through one instrument (e.g., blended finance).",
+      "extract_hint": "Look for source-to-instrument linkages — e.g., 'World Bank funding via green bond', 'federal grant channeled through revolving loan fund', 'multilateral climate fund via blended finance'."
+    },
+    {
+      "id": "WITHIN",
+      "label": "within",
+      "source": "Jurisdiction",
+      "target": "Jurisdiction",
+      "definition": "This jurisdiction is administratively contained within the target jurisdiction. Enables hierarchical nesting: municipality WITHIN county WITHIN state WITHIN country.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-one",
+      "notes": "Self-referential (Jurisdiction → Jurisdiction) for administrative hierarchy. Strictly hierarchical — no cycles allowed.",
+      "extract_hint": "Look for administrative containment — e.g., 'Miami-Dade County within the state of Florida', 'the borough of Manhattan within New York City'."
+    },
+    {
+      "id": "SHAPES",
+      "source": "UrbanSystem",
+      "target": "Vulnerability",
+      "label": "shapes",
+      "definition": "Urban system conditions (housing quality, infrastructure deficits, service gaps) produce or amplify vulnerability independent of hazard exposure. Reflects the IPCC AR6 position that vulnerability is socially constructed through systemic conditions.",
+      "properties": [],
+      "notes": "Captures socially constructed vulnerability. Complements ExposureUnit EXPERIENCES Vulnerability (hazard-linked vulnerability).",
+      "extract_hint": "Look for claims that infrastructure or service deficits create vulnerability — e.g., 'aging water systems leave low-income neighborhoods more vulnerable', 'lack of green space amplifies heat vulnerability'.",
+      "cardinality": "many-to-many"
+    },
+    {
+      "id": "REDUCES_EXPOSURE",
+      "source": "Solution",
+      "target": "ExposureUnit",
+      "label": "reduces exposure of",
+      "definition": "The solution reduces the exposure of a population, asset, or system to climate hazards (e.g., a sea wall protects a coastal neighborhood, relocation removes assets from the floodplain).",
+      "properties": [],
+      "notes": "One of three IPCC AR6 risk-reduction pathways: reduce hazard (MITIGATES), reduce exposure (REDUCES_EXPOSURE), reduce vulnerability (REDUCES).",
+      "extract_hint": "Look for claims about physical protection, relocation, or shielding from hazard impact — e.g., 'sea wall protects 10,000 residents', 'managed retreat removes assets from floodplain', 'levee system shields industrial zone'.",
+      "cardinality": "many-to-many"
+    },
+    {
+      "id": "SPECIFIES",
+      "label": "specifies",
+      "source": "Plan",
+      "target": "Action",
+      "cardinality": "one-to-many",
+      "definition": "The plan specifies this action as a discrete initiative or intervention to be undertaken.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "notes": "One-to-many: a plan contains multiple actions. Actions may optionally link to solution classes via IMPLEMENTS.",
+      "extract_hint": "Look for specific initiatives listed in a plan — e.g., 'Action 3.2: Install permeable pavement in all new developments', 'Priority action: Establish 15 new cooling centers by 2027'."
+    },
+    {
+      "id": "IMPLEMENTS",
+      "label": "implements",
+      "source": "Action",
+      "target": "Solution",
+      "definition": "The action deploys or instantiates this solution class. Links a specific plan commitment to the reusable solution type it represents. Optional: not all actions can be matched to a known solution class.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-one",
+      "notes": "Many-to-one: many actions can implement the same solution class (e.g., multiple cities' heat action plans all implement 'Heat Early Warning System'). Extraction should not fail when an action cannot be resolved to a known solution class.",
+      "extract_hint": "Look for action descriptions that map to known solution types — e.g., an action 'deploy flood sensors across 5 watersheds' implements the solution class 'Flood Early Warning System'."
+    },
+    {
+      "id": "PURSUES",
+      "label": "pursues",
+      "source": "Action",
+      "target": "ResilienceGoal",
+      "definition": "The action is intended to advance this resilience goal, as stated in the plan or disclosure. Planning-intent: what the plan says the action is for.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Primary path for goal alignment in plan documents and CDP disclosures, where goals are typically tagged at the action level rather than resolved to a solution class. Sits in the epistemic hierarchy between SETS_GOAL (plan aspiration) and CONTRIBUTES_TO (solution claim).",
+      "extract_hint": "Look for goal tags on actions — e.g., 'this action supports Goal 4: Promote cohesive communities', 'contributes to the infrastructure resilience dimension', 'targets improved public health outcomes'."
+    },
+    {
+      "id": "INFORMS",
+      "label": "informs",
+      "source": "PlanningData",
+      "target": "Plan",
+      "definition": "This data source informed the development of the plan. Captures the evidence base underlying planning decisions — e.g., downscaled climate projections, hazard maps, vulnerability assessments.",
+      "properties": [],
+      "notes": "Links PlanningData to Plan. Complements GENERATES (Solution → PlanningData) to form the chain: Solution GENERATES PlanningData, PlanningData INFORMS Plan.",
+      "extract_hint": "Look for data references in plan methodology sections — e.g., 'informed by NOAA downscaled climate projections', 'based on the 2024 citywide vulnerability assessment', 'uses flood hazard mapping from FEMA'.",
+      "cardinality": "many-to-many"
+    },
+    {
+      "id": "COVERS",
+      "label": "covers",
+      "source": "Plan",
+      "target": "Jurisdiction",
+      "definition": "The plan applies to or covers this geographic area or jurisdiction.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Direct plan-to-location link. A plan covers a jurisdiction even if no specific solutions or actions have been matched to locations within it.",
+      "extract_hint": "Look for geographic scope in plan titles and introductions — e.g., 'City of Rotterdam Climate Adaptation Strategy', 'covers the Greater Miami metropolitan area', 'applies to all five boroughs'."
+    },
+    {
+      "id": "ADDRESSES",
+      "label": "addresses",
+      "source": "Plan",
+      "target": "Hazard",
+      "definition": "The plan identifies, assesses, or addresses this climate hazard. Supports longitudinal comparison: successive plans linking to the same hazard node allow tracking how assessment and response evolve.",
+      "properties": [
+        {
+          "id": "assessment_scope",
+          "type": "enum",
+          "values": [
+            "identified",
+            "characterized",
+            "quantified"
+          ],
+          "required": false,
+          "note": "Depth of hazard treatment in the plan: identified (named), characterized (described qualitatively), quantified (modeled/measured)."
+        },
+        {
+          "id": "assessment_year",
+          "type": "integer",
+          "required": false,
+          "note": "Year the assessment was performed (may differ from plan adoption year)."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Unified relationship replacing former ADDRESSES_HAZARD + RISK_ASSESSED_IN pair. Use assessment_scope to distinguish depth of treatment.",
+      "extract_hint": "Look for hazards identified in plan risk assessments or targeted by adaptation strategies — e.g., 'addresses coastal flooding', 'assesses urban heat island risk under 2050 conditions', 'targets increasing wildfire risk'."
+    },
+    {
+      "id": "SUPERSEDES",
+      "label": "supersedes",
+      "source": "Plan",
+      "target": "Plan",
+      "definition": "This plan replaces or updates the target plan. Captures plan lineage and policy evolution over time.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "one-to-one",
+      "notes": "Self-referential (Plan → Plan). Tracks how plans evolve — useful for understanding policy continuity and change.",
+      "extract_hint": "Look for succession language — e.g., 'this strategy supersedes the 2015 Climate Action Plan', 'replaces and updates the previous resilience framework', 'builds upon and replaces the 2018 adaptation plan'."
+    },
+    {
+      "id": "TARGETS",
+      "label": "targets",
+      "source": "Plan",
+      "target": "UrbanSystem",
+      "definition": "The plan focuses on or explicitly targets this urban system or sector in its adaptation strategy.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Direct plan-to-system link. Captures sectoral scope of plans (e.g., a water infrastructure plan, a transport resilience plan).",
+      "extract_hint": "Look for sectoral focus in plan scope — e.g., 'focuses on water infrastructure resilience', 'targets the public transit network', 'addresses energy system vulnerabilities'."
+    },
+    {
+      "id": "ENGAGES",
+      "label": "engages",
+      "source": "Plan",
+      "target": "Stakeholder",
+      "definition": "The plan involves this stakeholder in its development, governance, or implementation oversight.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Plan-level stakeholder involvement. Distinct from IMPLEMENTED_BY (solution-level implementation) and PARTICIPATES_IN (solution-level participation).",
+      "extract_hint": "Look for stakeholder involvement in planning processes — e.g., 'developed in consultation with community groups', 'overseen by the Climate Resilience Commission', 'engages the private sector in implementation governance'."
+    },
+    {
+      "id": "GENERATES",
+      "label": "generates",
+      "source": "Solution",
+      "target": "PlanningData",
+      "definition": "The solution produces data outputs that can inform planning processes — e.g., a climate hazard model generates downscaled projections, a sensor network generates real-time monitoring data.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Completes the chain: Solution GENERATES PlanningData, PlanningData INFORMS Plan. Captures the feedback loop where solutions produce knowledge that shapes future planning.",
+      "extract_hint": "Look for data-producing solutions — e.g., 'the climate model generates localized flood projections', 'the sensor network produces real-time air quality data used in planning', 'vulnerability assessment tool outputs risk maps'."
+    },
+    {
+      "id": "LOCATED_IN",
+      "label": "located in",
+      "source": "ExposureUnit",
+      "target": "Jurisdiction",
+      "definition": "The exposure unit is geographically situated in this location.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-one",
+      "notes": "Spatially grounds exposure units. Enables location-based queries of exposed populations and assets.",
+      "extract_hint": "Look for location context around exposed populations or assets — e.g., 'the 30,000 residents in the coastal flood zone are in Rotterdam's Delfshaven district'."
+    },
+    {
+      "id": "SHIFTS_RISK_TO",
+      "label": "shifts risk to",
+      "source": "Solution",
+      "target": "ExposureUnit",
+      "definition": "The solution transfers or displaces climate risk to this exposure unit — a spatial maladaptation pattern where risk reduction in one area increases risk in another.",
+      "properties": [
+        {
+          "id": "mechanism",
+          "type": "string",
+          "required": false,
+          "note": "How the risk is transferred (e.g., 'upstream flood diversion increases downstream flood risk')."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Captures spatial maladaptation: solutions that protect one group by shifting risk to another. Complements Outcome.outcome_type = maladaptation (which captures temporal/functional maladaptation).",
+      "extract_hint": "Look for language about displaced risk or burden shifting — e.g., 'sea wall protects city center but increases flood risk in unprotected downstream communities'."
+    },
+    {
+      "id": "GOVERNS",
+      "label": "governs",
+      "source": "GovernanceStructure",
+      "target": "Plan",
+      "definition": "The governance structure has formal oversight, approval authority, or coordination responsibility over this plan.",
+      "properties": [
+        {
+          "id": "governance_role",
+          "type": "string",
+          "required": false,
+          "note": "Nature of governance relationship (e.g., 'approving body', 'coordinating authority', 'oversight committee')."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Links institutional governance layer to plans. A plan may be governed by multiple bodies (e.g., city council + regional authority).",
+      "extract_hint": "Look for governance or oversight language — e.g., 'the Climate Resilience Commission oversees implementation of the plan', 'approved by the interagency task force'."
+    },
+    {
+      "id": "COORDINATES_WITH",
+      "label": "coordinates with",
+      "source": "Stakeholder",
+      "target": "Stakeholder",
+      "definition": "The stakeholder coordinates with this other stakeholder on a specific adaptation initiative or planning process. Extract only when coordination is explicitly documented — do not infer from co-occurrence.",
+      "properties": [
+        {
+          "id": "coordination_context",
+          "type": "string",
+          "required": false,
+          "note": "The initiative or process around which coordination occurs."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Captures documented cross-agency or cross-sector coordination. Directionality is symmetric in practice; source is the actor whose coordination is documented. Do not infer from plan co-authorship or co-mention.",
+      "extract_hint": "Look for explicit coordination language — e.g., 'the city coordinates with the regional water authority on flood management', 'partnered with the transit agency to implement cooling corridors'."
+    },
+    {
+      "id": "BLOCKS",
+      "label": "blocks",
+      "source": "Barrier",
+      "target": "Solution",
+      "definition": "The barrier actively prevents or seriously impedes deployment of this solution. Signals that the barrier must be removed or substantially reduced for the solution to proceed — not merely worked around.",
+      "properties": [
+        {
+          "id": "severity",
+          "type": "enum",
+          "required": false,
+          "values": [
+            "partial",
+            "significant",
+            "prohibitive"
+          ],
+          "note": "Degree to which the barrier blocks the solution."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Stronger than FACES (Action → Barrier). BLOCKS indicates that the solution is fundamentally constrained by this barrier. Use when a plan or study explicitly states that a barrier prevents a solution from being deployed.",
+      "extract_hint": "Look for language explicitly linking a barrier to blocking a specific solution — e.g., 'regulatory barrier prevents deployment of green infrastructure in the right-of-way', 'absence of revenue mechanism blocks financing of flood sensors'."
+    },
+    {
+      "id": "MEMBER_OF",
+      "label": "member of",
+      "source": "Stakeholder",
+      "target": "GovernanceStructure",
+      "definition": "The stakeholder is a formal member of or participant in this governance structure.",
+      "properties": [
+        {
+          "id": "role",
+          "type": "string",
+          "required": false,
+          "note": "The stakeholder's role within the governance body (e.g., 'chair', 'voting member', 'observer')."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Extends PARTICIPATES_IN (Stakeholder → Solution) to the governance layer. Enables queries about institutional composition of governance bodies.",
+      "extract_hint": "Look for membership language — e.g., 'the water utility is represented on the task force', 'community organizations sit on the advisory committee'."
+    },
+    {
+      "id": "DEPLOYED_IN",
+      "label": "deployed in",
+      "source": "Action",
+      "target": "Jurisdiction",
+      "definition": "The plan action is geographically located in or targets this location. Provides a direct spatial link from plan commitments to places.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Complements IMPLEMENTED_IN (Solution → Location). Where IMPLEMENTED_IN captures the general solution deployment geography, DEPLOYED_IN captures where a specific plan action is committed. Enables spatial queries over plan commitments. See also the duplicate DEPLOYED_IN row sourced from CapitalProject (added v0.2) for the budget-document equivalent.",
+      "extract_hint": "Look for location-specific action language — e.g., 'install flood barriers along the southern waterfront', 'establish cooling centers in 12 districts', 'retrofit buildings in the Eastside neighborhood'."
+    },
+    {
+      "id": "DEPLOYED_IN",
+      "label": "deployed in",
+      "source": "CapitalProject",
+      "target": "Jurisdiction",
+      "definition": "The capital project is sited at or targets this location. Provides a direct spatial link from budget-document line items to places — needed for risk-shed overlap analysis (does this CIP project sit in a hazard zone?).",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.2. Mirrors the Action → Location DEPLOYED_IN row at the budget-document grain. Same relationship id and label; the viewer keys edges by id+source+target so duplication is intentional and safe. Test CapitalProject DEPLOYED_IN Location against Hazard EXPOSES ExposureUnit (at the same Location) to identify climate-relevant projects.",
+      "extract_hint": "Look for project-site language in CIPs — e.g., 'project sited at the West End wastewater plant', 'flood-wall segment along NE 4th Street', 'CIP 23-PRK-022 at Lummus Park'."
+    },
+    {
+      "id": "REALIZES",
+      "label": "realizes",
+      "source": "CapitalProject",
+      "target": "Action",
+      "definition": "The capital project (a budget-document line item) delivers on, or partially fulfills, this climate-plan action commitment. The bridge between climate-plan language (Action) and capital-budget execution (CapitalProject). Optional: many capital projects don't realize any climate-plan action; many climate-plan actions are unfunded.",
+      "properties": [
+        {
+          "id": "fulfillment_share",
+          "type": "string",
+          "required": false,
+          "note": "Free-text qualifier for how completely this project delivers on the action (e.g., 'partial — covers Phase 1 only', 'full', 'one of three projects realizing this action'). Free-text for now."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.2. Enables the plan↔budget alignment query: which capital projects fulfill which climate-plan commitments, and which commitments have no funded projects realizing them? When this edge is absent for a CapitalProject, the project is either non-climate-relevant or its climate-plan linkage hasn't been resolved.",
+      "extract_hint": "Look for cross-references between CIPs and climate plans — e.g., 'this project implements Action 4.2 of the 2024 Resilience Strategy', 'fulfills the Heat Action Plan's cooling-center commitment', 'one of two CIP projects delivering on Goal 7 of the climate plan'."
+    },
+    {
+      "id": "USES_INSTRUMENT",
+      "label": "uses financial instrument",
+      "source": "CapitalProject",
+      "target": "FinancialInstrument",
+      "definition": "The capital project is financed using this financial mechanism or instrument. Mirrors Solution USES_INSTRUMENT FinancialInstrument at the project grain.",
+      "properties": [
+        {
+          "id": "amount_usd",
+          "type": "number",
+          "required": false
+        },
+        {
+          "id": "share_percent",
+          "type": "number",
+          "required": false,
+          "note": "Fraction of total project cost covered by this instrument (0–1)"
+        },
+        {
+          "id": "financing_model",
+          "type": "enum",
+          "required": false,
+          "vocab": "financing_model",
+          "note": "How capital is structured for this draw (grant, debt, equity, etc.)"
+        },
+        {
+          "id": "description",
+          "type": "string",
+          "required": false
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.2. The full project-level financing path: FinancingSource CHANNELS_THROUGH FinancialInstrument, CapitalProject USES_INSTRUMENT FinancialInstrument, CapitalProject FUNDED_BY FinancingSource. Carries debt-instrument linkage so that project-level annual debt service is queryable via FinancialInstrument's v0.2 properties (principal, term, interest rate, annual_debt_service_usd).",
+      "extract_hint": "Look for financing instruments tied to projects — e.g., 'funded through a 30-year general obligation bond', 'financed via the state revolving fund', 'supported by a federal cost-share grant'."
+    },
+    {
+      "id": "COMMISSIONED_BY",
+      "label": "commissioned by",
+      "source": "CapitalProject",
+      "target": "Stakeholder",
+      "definition": "The capital project is commissioned, sponsored, or owned by this stakeholder — typically the municipal agency that holds the project on its capital budget (e.g., DEP, DOT, Parks). Distinct from IMPLEMENTED_BY (who carries out the work, which may be an external contractor or a different agency).",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-one",
+      "notes": "v0.2. Enables agency-level analysis of capital programming — e.g., 'which agencies are commissioning the most resilience capex?', 'how is the public-safety program sponsoring climate-relevant projects?'.",
+      "extract_hint": "Look for the sponsoring agency in CIP entries — e.g., 'Department of Environmental Protection', 'sponsoring agency: DOT', 'Parks & Recreation Department'."
+    },
+    {
+      "id": "IMPLEMENTED_BY",
+      "label": "implemented by",
+      "source": "CapitalProject",
+      "target": "Stakeholder",
+      "definition": "The capital project is implemented or operated by this stakeholder. Mirrors the Solution IMPLEMENTED_BY Stakeholder pattern at the project grain. Distinct from COMMISSIONED_BY (which captures the sponsoring/owning agency, not the executing party).",
+      "properties": [
+        {
+          "id": "role",
+          "type": "string",
+          "required": false,
+          "note": "Specific role (e.g., 'lead implementer', 'design-build contractor', 'O&M operator')."
+        },
+        {
+          "id": "is_lead",
+          "type": "boolean",
+          "required": false,
+          "note": "True if this is the primary implementing actor."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.2. Mirrors Solution IMPLEMENTED_BY Stakeholder. Same relationship id; viewer keys edges by id+source+target so duplication is intentional.",
+      "extract_hint": "Look for who delivers the project — e.g., 'design-build by AECOM', 'constructed by the city water utility's in-house engineering team', 'O&M operator: South Florida Water Management District'."
+    },
+    {
+      "id": "PRODUCES",
+      "label": "produces",
+      "source": "CapitalProject",
+      "target": "Outcome",
+      "definition": "The capital project produces this outcome — typically a quantified asset-protection benefit, monetized co-benefit, or operational result. Mirrors Solution PRODUCES Outcome at the project grain. This is the attachment point for project-level monetized co-benefits (Outcome.monetized_value_usd, value_recurrence, beneficiary_program — added v0.2).",
+      "properties": [
+        {
+          "id": "outcome_type",
+          "type": "enum",
+          "required": true,
+          "note": "Category of outcome. Values from outcome_type in enums (effectiveness_indicator, co_benefit, failure_mode, maladaptation, other).",
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "outcome_type"
+          }
+        },
+        {
+          "id": "evidence_level",
+          "type": "enum",
+          "required": false,
+          "vocabulary_binding": {
+            "vocab": "enums",
+            "field": "evidence_level"
+          }
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "one-to-many",
+      "notes": "v0.2. Mirrors Solution PRODUCES Outcome. Project-level outcomes are typically monetized (avoided damages, revenue stability, operational savings) and tagged with beneficiary_program to capture cross-program ripple effects (transit, parks, public safety, etc.).",
+      "extract_hint": "Look for documented project benefits — e.g., 'project protects $500M in coastal property', 'reduces stormwater treatment cost by $2M/yr', 'avoids an estimated $80M in flood damages over the asset life'. Capture monetized_value_usd, value_recurrence, and beneficiary_program on the resulting Outcome."
+    },
+    {
+      "id": "SPECIFIES",
+      "label": "specifies",
+      "source": "Plan",
+      "target": "CapitalProject",
+      "cardinality": "one-to-many",
+      "definition": "The plan (a Capital Improvement Plan or capital budget) specifies this capital project as a line item. Mirrors Plan SPECIFIES Action at the budget-document grain.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "notes": "v0.2. Mirrors Plan SPECIFIES Action. Used when Plan.plan_type is capital_improvement_plan or capital_budget. A single CIP typically SPECIFIES many CapitalProjects.",
+      "extract_hint": "Look for line items inside CIP documents — e.g., 'Project 23-WTR-015: Watershed Drainage Improvements, $50M, FY26-FY30', 'CIP-2026-042: South Beach Resilience Wall'."
+    },
+    {
+      "id": "CONTINGENT_ON",
+      "label": "contingent on",
+      "source": "FinancialInstrument",
+      "target": "Outcome",
+      "definition": "Repayment, return, or rate adjustment of this financial instrument is contingent on the achievement of this measured outcome. Models pay-for-success instruments (outcome bonds, environmental impact bonds, sustainability-linked loans with outcome triggers).",
+      "properties": [
+        {
+          "id": "trigger_threshold",
+          "type": "string",
+          "required": false,
+          "note": "The outcome threshold that triggers payment or rate adjustment (e.g., '30% reduction in stormwater runoff', 'avoided flood damages exceed $10M')."
+        },
+        {
+          "id": "evaluation_period",
+          "type": "string",
+          "required": false,
+          "note": "Timeframe over which the outcome is measured to determine contingency (e.g., '3 years post-construction', 'annual review')."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.3. Enables queries like 'which outcomes are tied to financial returns?' and 'which instruments have unmet performance triggers?'. Generalizes beyond outcome bonds — sustainability_linked_loan instruments may also carry this edge when their rate adjustment is tied to a specific measured outcome.",
+      "extract_hint": "Look for performance-linked finance language — e.g., 'repayment contingent on achieving 25% runoff reduction', 'interest rate steps down if green infrastructure meets performance targets', 'pay-for-success contract tied to flood damage avoidance'."
+    },
+    {
+      "id": "WITHIN",
+      "label": "within",
+      "source": "Place",
+      "target": "Jurisdiction",
+      "definition": "This place is geographically located within the target jurisdiction.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": true
+        }
+      ],
+      "cardinality": "many-to-one",
+      "notes": "Links non-jurisdictional geographic features to their containing administrative unit.",
+      "extract_hint": "Look for geographic containment of features in jurisdictions — e.g., 'the Biscayne Bay watershed in Miami-Dade County', 'Central Park in New York City'."
+    },
+    {
+      "id": "GOVERNS",
+      "label": "governs",
+      "source": "Stakeholder",
+      "target": "Jurisdiction",
+      "definition": "The stakeholder (typically a municipal or regional government entity) has formal governing authority over this jurisdiction.",
+      "properties": [
+        {
+          "id": "governance_role",
+          "type": "string",
+          "required": false,
+          "note": "Nature of governance relationship (e.g., 'municipal government', 'county authority', 'regional council')."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Models the city-as-institution (Stakeholder) governing the city-as-place (Jurisdiction). A jurisdiction may be governed by multiple bodies (e.g., city + county + regional authority).",
+      "extract_hint": "Look for governing authority language — e.g., 'the City of Miami governs…', 'administered by the Greater London Authority'."
+    },
+    {
+      "id": "AFFECTED_BY",
+      "label": "affected by",
+      "source": "Jurisdiction",
+      "target": "Hazard",
+      "definition": "This jurisdiction is affected by this climate hazard, as documented by reference datasets, climate projections, or hazard assessments.",
+      "properties": [
+        {
+          "id": "source_dataset",
+          "type": "string",
+          "required": true,
+          "note": "Identifier of the reference dataset providing the hazard exposure data (e.g., \"wri_city_hazards_1p5_2_3C\")."
+        },
+        {
+          "id": "indicators",
+          "type": "object",
+          "required": false,
+          "note": "JSONB payload of climate indicator metrics grouped by indicator type, with scenario-level expected values and exceedance probabilities."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "Direct link between jurisdictions and the hazards that threaten them, based on climate projections or hazard assessments. Complements the indirect path Hazard → EXPOSES → ExposureUnit → LOCATED_IN → Jurisdiction. Edge properties carry quantitative indicator data when available.",
+      "extract_hint": "Look for statements that a city or region faces, is exposed to, or is threatened by a specific climate hazard — e.g., \"Miami faces increased coastal flooding risk\", \"the city is highly exposed to extreme heat\"."
+    },
+    {
+      "id": "ADDRESSES",
+      "label": "addresses",
+      "source": "Action",
+      "target": "Hazard",
+      "definition": "The action is reported as addressing this climate hazard. Action-grain counterpart to Plan ADDRESSES Hazard: captures the hazard a specific committed initiative responds to, as stated in plans or CDP city-action disclosures (the climate_hazard_s_that_action field). Distinct from Solution MITIGATES Hazard (proven mitigation at the solution-class level) and from Plan ADDRESSES Hazard (plan-level assessment).",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.6. Same relationship id as Plan ADDRESSES Hazard and ResilienceGoal ADDRESSES Hazard; the viewer keys edges by id+source+target so the three grains coexist. Carries no assessment_scope/assessment_year — those are plan-assessment concepts that do not apply at the action grain.",
+      "extract_hint": "Look for the hazard an action responds to — e.g., CDP climate_hazard_s_that_action = 'Urban flooding, Heavy precipitation' on an action 'Upgrade stormwater drainage in low-lying neighborhoods'."
+    },
+    {
+      "id": "ADDRESSES",
+      "label": "addresses",
+      "source": "ResilienceGoal",
+      "target": "Hazard",
+      "definition": "The resilience goal targets this climate hazard as a risk it is intended to reduce. Goal-grain hazard association sourced from the 2024 resilience fact table (the goal_hazards field). Captures which hazards a high-level resilience objective addresses, independent of any single plan or action.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.6. A goal-level risk target — must not be downgraded to Plan ADDRESSES Hazard nor treated as an action-level association. Same relationship id as the Plan and Action ADDRESSES Hazard rows, distinguished by source. Extends the ResilienceGoal bridge entity, which previously connected only via SETS, PURSUES, CONTRIBUTES_TO, and DEMONSTRATES_PROGRESS_ON.",
+      "extract_hint": "Look for the hazards a resilience goal is framed around — e.g., a goal 'Reduce flood risk for vulnerable coastal communities' with goal_hazards = 'Coastal flooding, Storm surge'."
+    },
+    {
+      "id": "TARGETS",
+      "label": "targets",
+      "source": "Action",
+      "target": "UrbanSystem",
+      "definition": "The action focuses on or acts on this urban system or sector. Action-grain counterpart to Plan TARGETS UrbanSystem: captures the sector/system an action targets, as stated in plans or CDP city-action disclosures (the sectors_adaptation_action field). Does not require the action to first resolve to a canonical Solution — many CDP actions are free-text operational actions that cannot.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.6. Same relationship id as Plan TARGETS UrbanSystem and CapitalProject TARGETS UrbanSystem; the viewer keys edges by id+source+target so the grains coexist. Provides a direct Action→UrbanSystem edge without mandating the Action→Solution→OPERATES_ON→UrbanSystem path.",
+      "extract_hint": "Look for the sector/system an action targets — e.g., CDP sectors_adaptation_action = 'Buildings' on an action 'Retrofit public housing for heat resilience'."
+    },
+    {
+      "id": "TARGETS",
+      "label": "targets",
+      "source": "CapitalProject",
+      "target": "UrbanSystem",
+      "definition": "The capital project's primary system or asset domain. Project-grain counterpart to Plan TARGETS UrbanSystem, sourced from CDP project_area. Promotes system domain from the asset_class property to a queryable graph edge: the project tells us the system domain even when it cannot be resolved to a canonical Solution.",
+      "properties": [
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.6. Refines the v0.2 'CapitalProject Edge Economy' decision, which collapsed system domain into the asset_class property and omitted a direct edge. asset_class remains as the budget-document's local annotation; TARGETS UrbanSystem is the bound, queryable graph edge. Uses TARGETS (the program-grain 'focuses on this system'), not Solution-grain OPERATES_ON. Same relationship id as Plan/Action TARGETS UrbanSystem.",
+      "extract_hint": "Look for the system domain of a CIP line item — e.g., CDP project_area = 'Water supply / wastewater infrastructure' on a project 'New wastewater pumping station'."
+    },
+    {
+      "id": "FUNDED_BY",
+      "label": "funded by",
+      "source": "Action",
+      "target": "FinancingSource",
+      "definition": "The action is funded by this financing source. Action-grain funding link sourced from CDP city-action disclosures (the funding_source_s field). Captures funding at the action level — many CDP actions name a funding source but do not correspond to a CapitalProject or resolve to a FinancialInstrument, so this keeps funding information as a queryable edge rather than buried in metadata.",
+      "properties": [
+        {
+          "id": "amount_usd",
+          "type": "number",
+          "required": false
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.6. First definition of FUNDED_BY in the relationships array. Distinct from USES_INSTRUMENT (→ FinancialInstrument, the structural form of the capital): FUNDED_BY names who provides the money. Same relationship id as CapitalProject FUNDED_BY FinancingSource.",
+      "extract_hint": "Look for the funder named on an action — e.g., CDP funding_source_s = 'Emergency Tree Fund, municipal budget' on an action 'Urban tree planting programme'."
+    },
+    {
+      "id": "FUNDED_BY",
+      "label": "funded by",
+      "source": "CapitalProject",
+      "target": "FinancingSource",
+      "definition": "The capital project is funded by this financing source. Completes the project-level financing chain: FinancingSource ←FUNDED_BY← CapitalProject →USES_INSTRUMENT→ FinancialInstrument ←CHANNELS_THROUGH← FinancingSource.",
+      "properties": [
+        {
+          "id": "amount_usd",
+          "type": "number",
+          "required": false
+        },
+        {
+          "id": "share_percent",
+          "type": "number",
+          "required": false,
+          "note": "Fraction of total project cost provided by this source (0–1). Mirrors CapitalProject USES_INSTRUMENT.share_percent."
+        },
+        {
+          "id": "claim_ids",
+          "type": "array<uuid>",
+          "required": false
+        }
+      ],
+      "cardinality": "many-to-many",
+      "notes": "v0.6. Lands the FUNDED_BY edge that v0.2's change_history, the 'Resilience Finance — Five-Axis Split' design note, and the CapitalProject USES_INSTRUMENT notes all referenced but which was never actually added to the relationships array. Same relationship id as Action FUNDED_BY FinancingSource.",
+      "extract_hint": "Look for the funder(s) backing a CIP line item — e.g., 'South Beach Resilience Wall, federal cost-share + GO bond' names a federal source and a municipal source."
+    }
+  ],
+  "vocabularies": [
+    {
+      "id": "hazards",
+      "label": "UNDRR HIPs 2025 Hazard Taxonomy",
+      "type": "external",
+      "url": "",
+      "description": "7 hazard clusters and 50 specific hazards from the UNDRR-ISC Hazard Information Profiles 2025. Individual hazards crosswalked to C40/Arup (climate) and RCC (non-climate) sources.",
+      "bound_to": [
+        "Hazard.hazard_id",
+        "Hazard.hazard_category"
+      ],
+      "terms_count": 50
+    },
+    {
+      "id": "urban-systems",
+      "label": "Urban Systems Taxonomy",
+      "type": "internal",
+      "url": "",
+      "description": "Hierarchical classification of urban infrastructure and services (sector → subsector → system)",
+      "bound_to": [
+        "UrbanSystem.system_id",
+        "UrbanSystem.sector",
+        "UrbanSystem.subsector"
+      ],
+      "terms_count": null
+    },
+    {
+      "id": "solution-categories",
+      "label": "Solution Categories",
+      "type": "internal",
+      "url": "",
+      "description": "Internal taxonomy for classifying adaptation solutions by type",
+      "bound_to": [
+        "Solution.category_id",
+        "Solution.subcategory_id"
+      ],
+      "terms_count": null
+    },
+    {
+      "id": "crf-goals",
+      "label": "City Resilience Framework 2024",
+      "type": "external",
+      "url": "https://www.arup.com/perspectives/publications/research/section/city-resilience-framework",
+      "description": "Arup's City Resilience Framework 2024 — 4 dimensions, 22 goals for urban resilience",
+      "bound_to": [
+        "ResilienceGoal.goal_id",
+        "ResilienceGoal.dimension"
+      ],
+      "terms_count": 22
+    },
+    {
+      "id": "enums",
+      "label": "Schema Enumerations",
+      "type": "internal",
+      "url": "",
+      "description": "Standard enumerated values defined in extraction schema (e.g., actor_type, outcome_type, evidence_level, mechanism_type)",
+      "bound_to": [
+        "various"
+      ],
+      "terms_count": null,
+      "note": "Collection of small controlled vocabularies for specific fields"
+    },
+    {
+      "id": "vulnerable-populations",
+      "label": "Vulnerable Populations",
+      "type": "internal",
+      "url": "",
+      "description": "21 socially-defined population groups facing disproportionate climate vulnerability. Drawn from IPCC AR6, UNDRR Sendai Framework, EDF equity framework, and housing-tenure research (Bradshaw et al. 2025).",
+      "bound_to": [
+        "Solution.target_populations",
+        "Vulnerability.affected_group",
+        "ExposureUnit.affected_group",
+        "Stakeholder.target_populations"
+      ],
+      "terms_count": 21,
+      "note": "21 socially-defined population groups facing disproportionate climate vulnerability, drawn from IPCC AR6, UNDRR Sendai Framework, EDF equity framework, and housing-tenure research (Bradshaw et al. 2025)."
+    }
+  ],
+  "metadata": {
+    "types_count": 22,
+    "relationships_count": 60,
+    "vocabularies_count": 6,
+    "change_history": [
+      "v0.6 (2026-06-30): Action-, goal-, and project-level edges for CDP city-action and 2024 fact-table data — Action ADDRESSES Hazard, Action TARGETS UrbanSystem, Action FUNDED_BY FinancingSource, ResilienceGoal ADDRESSES Hazard, CapitalProject TARGETS UrbanSystem; landed the FUNDED_BY relationship (CapitalProject → FinancingSource) referenced since v0.2 but never defined",
+      "v0.2 (2026-05-05): Resilience finance extension — CapitalProject entity, debt-service properties on FinancialInstrument, FUNDED_BY/COMMISSIONED_BY/REALIZES relationships, US municipal CIP financing instruments, monetized co-benefit valuation, capital_improvement_plan + capital_budget plan types, bound previously-orphaned financing_status and financing_model enums",
+      "v0.1.1 (2026-05-04): Peer review response — UNDRR HIPs 2025 hazard restructure, ICLEI five-pathway crosswalk, EbA/CbA subcategories, informal-service-systems subsector, housing-tenure populations, AF/GCF accreditation modalities on FinancingSource",
+      "v0.1 (2026-04-30): Initial public release"
+    ],
+    "design_notes": [
+      {
+        "topic": "IPCC AR6 Risk-Reduction Pathways",
+        "note": "The ontology represents three pathways through which solutions reduce climate risk per IPCC AR6 (Risk = f(Hazard, Exposure, Vulnerability)): (1) Solution MITIGATES Hazard — reduce hazard intensity or frequency; (2) Solution REDUCES_EXPOSURE ExposureUnit — shield, relocate, or protect exposed populations/assets; (3) Solution REDUCES Vulnerability — reduce sensitivity or build adaptive capacity. Mechanism (via WORKS_BY) describes the functional process by which a solution achieves any of these pathways."
+      },
+      {
+        "topic": "Socially Constructed Vulnerability",
+        "note": "UrbanSystem SHAPES Vulnerability reflects the position in IPCC AR6 that vulnerability is socially produced through systemic conditions (housing quality, infrastructure deficits, service gaps) independent of hazard exposure. This complements ExposureUnit EXPERIENCES Vulnerability which captures hazard-linked vulnerability."
+      },
+      {
+        "topic": "Solution vs Action",
+        "note": "Solution is a reusable class of adaptation intervention (what it IS, independent of place or plan). Action is a specific, time-bound plan commitment with budget, timeline, and implementation status. The full chain is Plan CONTAINS_ACTION Action, Action optionally IMPLEMENTS Solution. Actions connect directly to goals (TARGETS_GOAL) and outcomes (RESULTS_IN) independent of solution resolution."
+      },
+      {
+        "topic": "Epistemic Hierarchy for Resilience Goals",
+        "note": "Four relationship types connect to ResilienceGoal, forming an epistemic hierarchy from aspiration to evidence: SETS_GOAL (plan aspiration), TARGETS_GOAL (action intent from plan/disclosure), CONTRIBUTES_TO (solution-class claim), DEMONSTRATES_PROGRESS_ON (measured outcome evidence)."
+      },
+      {
+        "topic": "Resilience Finance — Five-Axis Split (v0.2)",
+        "note": "v0.2 extends Decision 27's four-axis split (who funds → how accredited → what instrument → what mechanism) with a fifth axis at the project grain: who funds (FinancingSource) → how accredited (accreditation_modality) → what instrument carries the capital, with debt-service terms (FinancialInstrument: principal/term/rate/annual debt service) → what budget line item receives it (CapitalProject) → what the solution physically does (Mechanism). The full project-level financing chain is now: FinancingSource ←FUNDED_BY← CapitalProject →USES_INSTRUMENT→ FinancialInstrument ←CHANNELS_THROUGH← FinancingSource."
+      },
+      {
+        "topic": "Action vs CapitalProject (v0.2)",
+        "note": "Action is what a climate plan commits to doing; CapitalProject is what a capital budget actually programs and funds. Distinct entities with distinct provenance (climate plan vs CIP/budget document). The REALIZES edge bridges them and is the axis of the plan↔budget alignment query: which CapitalProjects REALIZE Actions that PURSUE a ResilienceGoal? Conversely, which Actions have no CapitalProjects realizing them (unfunded commitments)?"
+      },
+      {
+        "topic": "CapitalProject Edge Economy (v0.2, revised v0.6)",
+        "note": "CapitalProject deliberately omits direct edges that are reachable via multi-hop paths: IMPLEMENTS Solution (reach via REALIZES Action → IMPLEMENTS Solution); MITIGATES Hazard / REDUCES_EXPOSURE / REDUCES Vulnerability (reach via Solution); PURSUES ResilienceGoal (reach via Action); PROTECTS ExposureUnit (reach via Solution → REDUCES_EXPOSURE). v0.6 REVERSED the system-domain part of this decision: v0.2 collapsed the project's system domain into the asset_class property and omitted a direct edge, but asset_class is a coarse local annotation, not a queryable graph edge, and CDP project_area supplies the system domain directly even when the project cannot be resolved to a canonical Solution — so v0.6 adds a direct CapitalProject TARGETS UrbanSystem edge (asset_class is retained alongside it). BUNDLES_WITH (CapitalProject ↔ CapitalProject) for cross-program co-financing is deferred until first CIP ingestion shows whether bundles are extractable in practice."
+      },
+      {
+        "topic": "Action-level CDP edges & FUNDED_BY landing (v0.6)",
+        "note": "CDP city-action records and the 2024 resilience fact table tag hazards, sectors, and funders at the action and goal grain, not the plan grain. Forcing these onto Plan-level edges (Plan ADDRESSES Hazard, Plan TARGETS UrbanSystem) misattributes them, and requiring an Action → Solution resolution first is infeasible because many CDP actions are free-text operational actions. v0.6 therefore adds action/goal/project-grain rows reusing the existing ADDRESSES, TARGETS, and FUNDED_BY relationship ids (the viewer and graph model key edges by id + source + target, so grains coexist): Action ADDRESSES Hazard (climate_hazard_s_that_action), ResilienceGoal ADDRESSES Hazard (2024 fact-table goal_hazards), Action TARGETS UrbanSystem (sectors_adaptation_action), Action FUNDED_BY FinancingSource (funding_source_s), and CapitalProject TARGETS UrbanSystem (project_area). FUNDED_BY had been referenced in v0.2's change_history, the 'Resilience Finance — Five-Axis Split' design note, and the CapitalProject USES_INSTRUMENT notes but was never actually present in the relationships array; v0.6 defines it for the first time, with both the Action → FinancingSource row and the long-referenced CapitalProject → FinancingSource row."
+      }
+    ]
+  },
+  "version_notes": [
+    {
+      "version": "v0.6",
+      "date": "2026-06-30",
+      "summary": "Action-, goal-, and project-level edges for CDP city-action and 2024 fact-table data, and the long-missing FUNDED_BY relationship is finally defined.",
+      "changes": [
+        {
+          "type": "added",
+          "text": "ADDRESSES (Action → Hazard) — action-grain hazard link from CDP climate_hazard_s_that_action; reuses the ADDRESSES id alongside Plan → Hazard"
+        },
+        {
+          "type": "added",
+          "text": "ADDRESSES (ResilienceGoal → Hazard) — goal-grain hazard target from the 2024 fact-table goal_hazards; reuses the ADDRESSES id"
+        },
+        {
+          "type": "added",
+          "text": "TARGETS (Action → UrbanSystem) — action-grain sector/system link from CDP sectors_adaptation_action; reuses the TARGETS id alongside Plan → UrbanSystem"
+        },
+        {
+          "type": "added",
+          "text": "TARGETS (CapitalProject → UrbanSystem) — project-grain system domain from CDP project_area; promotes system domain from the asset_class property to a queryable edge"
+        },
+        {
+          "type": "added",
+          "text": "FUNDED_BY (Action → FinancingSource) — action-grain funding link from CDP funding_source_s, with amount_usd and claim_ids"
+        },
+        {
+          "type": "fixed",
+          "text": "FUNDED_BY (CapitalProject → FinancingSource) defined for the first time — referenced in v0.2's change_history, the 'Resilience Finance — Five-Axis Split' design note, and the CapitalProject USES_INSTRUMENT notes since v0.2 but never present in the relationships array; carries amount_usd, share_percent, and claim_ids"
+        },
+        {
+          "type": "changed",
+          "text": "entity notes updated for Action, ResilienceGoal, CapitalProject; 'CapitalProject Edge Economy' design note revised to record the system-domain reversal; new 'Action-level CDP edges & FUNDED_BY landing (v0.6)' design note added"
+        },
+        {
+          "type": "fixed",
+          "text": "corrected drifted metadata counts: relationships_count → 60 (the v0.5.1 array already held 54 rows but declared 51; +6 new v0.6 rows = 60) and types_count 21 → 22 (Place, added in v0.5.0, was never counted)"
+        }
+      ]
+    },
+    {
+      "version": "v0.4.1",
+      "date": "2026-05-14",
+      "summary": "Vocabulary alignment sweep — fix enum drift between ontology schema and enums.json, add missing sectors and population types.",
+      "changes": [
+        {
+          "type": "added",
+          "text": "EnablingCondition.condition_type: added 'political' (was already present on Barrier.barrier_type)"
+        },
+        {
+          "type": "added",
+          "text": "UrbanSystem.sector enum: added agriculture__food_systems and emergency__disaster_management (already in urban-systems.json since v0.1.1)"
+        },
+        {
+          "type": "changed",
+          "text": "vocabularies[vulnerable-populations] terms_count: 18 → 21 (3 housing-tenure populations added in v0.1.1)"
+        },
+        {
+          "type": "removed",
+          "text": "UrbanSystem vocabulary_binding for enums.condition (stale pointer to non-existent block; values are inline)"
+        },
+        {
+          "type": "changed",
+          "text": "enums.json: added outcome_bond to instrument_type, removed orphaned scale_of_deployment and implementation_status blocks, updated co_benefit_category to match ontology's 12-value set"
+        }
+      ]
+    },
+    {
+      "version": "v0.4",
+      "date": "2026-05-14",
+      "summary": "Hazard schema alignment with UNDRR HIPs 2025 — replace hazard_category enum with 7 HIPs clusters, add c40_arup_category crosswalk property, update all metadata.",
+      "changes": [
+        {
+          "type": "changed",
+          "text": "Hazard.hazard_category enum: replaced 13 C40/Arup category values with 7 UNDRR HIPs 2025 cluster IDs (meteorological_hydrological, geohazards, environmental, biological, chemical, technological, societal)"
+        },
+        {
+          "type": "added",
+          "text": "Hazard.c40_arup_category optional property: legacy crosswalk to C40/Arup category IDs (populated from hazards.json c40_arup_category field)"
+        },
+        {
+          "type": "changed",
+          "text": "vocabularies[hazards] label/description/terms_count updated from 'C40/Arup Climate Hazard Typology (13 categories, 31 hazards)' to 'UNDRR HIPs 2025 Hazard Taxonomy (7 clusters, 50 hazards)'"
+        },
+        {
+          "type": "changed",
+          "text": "Hazard type definition, notes, and vocabulary_bindings now reference UNDRR HIPs 2025 as primary structure"
+        }
+      ]
+    },
+    {
+      "version": "v0.3",
+      "date": "2026-05-07",
+      "summary": "Schema cleanup and outcome-linked finance — remove redundant IMPROVES relationship, drop denormalized label columns, add performance-linked finance support.",
+      "changes": [
+        {
+          "type": "removed",
+          "text": "IMPROVES relationship (Solution → UrbanSystem). System improvements should be routed through Outcome nodes via PRODUCES."
+        },
+        {
+          "type": "removed",
+          "text": "Hazard.hazard_name property (denormalized label — resolve via vocabulary join on hazard_id)"
+        },
+        {
+          "type": "removed",
+          "text": "ResilienceGoal.goal_text property (denormalized label — resolve via vocabulary join on goal_id)"
+        },
+        {
+          "type": "added",
+          "text": "FinancialInstrument.instrument_type: outcome_bond (pay-for-success / environmental impact bond — repayment contingent on measured outcomes)"
+        },
+        {
+          "type": "added",
+          "text": "CONTINGENT_ON relationship (FinancialInstrument → Outcome) with trigger_threshold and evaluation_period properties — models pay-for-success instruments"
+        },
+        {
+          "type": "changed",
+          "text": "Definition/notes deconflicted across all entity types: removed redundancies, updated Plan/Action notes to reference current relationship IDs, shortened CapitalProject definition"
+        }
+      ]
+    },
+    {
+      "version": "v0.2",
+      "date": "2026-05-05",
+      "summary": "Resilience finance extension — CapitalProject entity for budget-document line items, debt-service modeling, structured multi-source funding stack, monetized co-benefits with cross-program tagging. Source: meeting with Andy Salkin (Resilient Cities Catalyst), NYC, 5 May 2026.",
+      "changes": [
+        {
+          "type": "added",
+          "text": "CapitalProject entity for capital-budget / CIP line items (project_id, asset_class, total_capex_usd, annual_opex_usd, asset_life_years, construction_phase, funding_year_breakdown, financing_status, is_climate_relevant)"
+        },
+        {
+          "type": "added",
+          "text": "FinancialInstrument debt-service properties: principal_amount_usd, interest_rate, loan_term_years, annual_debt_service_usd, issuance_year, maturity_year, issuer, credit_rating"
+        },
+        {
+          "type": "added",
+          "text": "FinancialInstrument.instrument_type extended with US municipal CIP terms: general_obligation_bond, revenue_bond, tax_increment_financing, special_assessment, federal_cost_share, state_cost_share, municipal_capital_appropriation, ratepayer_funded, other"
+        },
+        {
+          "type": "added",
+          "text": "REALIZES relationship (CapitalProject → Action) — bridges climate-plan commitments and capital-budget execution, enables plan↔budget alignment queries"
+        },
+        {
+          "type": "added",
+          "text": "COMMISSIONED_BY relationship (CapitalProject → Stakeholder) — captures sponsoring agency, distinct from IMPLEMENTED_BY"
+        },
+        {
+          "type": "added",
+          "text": "USES_INSTRUMENT, IMPLEMENTED_BY, PRODUCES, DEPLOYED_IN, SPECIFIES extended (as duplicate-id rows) to also accept CapitalProject as source/target. USES_INSTRUMENT (CapitalProject → FinancialInstrument) carries funding-stack properties: amount_usd, share_percent, financing_model."
+        },
+        {
+          "type": "added",
+          "text": "Outcome: monetized_value_usd, value_recurrence (one_time/annual/lifetime), valuation_method, beneficiary_program (transportation, parks_recreation, public_safety, public_health, housing, schools, water_utilities, energy_utilities, pensions, general_revenue, other)"
+        },
+        {
+          "type": "added",
+          "text": "Outcome.co_benefit_type extended with finance-relevant categories: asset_protection, revenue_stability, operational_cost_reduction, tax_base_protection, service_continuity"
+        },
+        {
+          "type": "added",
+          "text": "Plan.plan_type extended with capital_improvement_plan and capital_budget"
+        },
+        {
+          "type": "added",
+          "text": "Action.financing_status property bound to enums.json#financing_status (previously orphaned)"
+        },
+        {
+          "type": "extended",
+          "text": "CHANNELS_THROUGH (FinancingSource → FinancialInstrument) extended with amount_usd — captures how much a source contributes to capitalising an instrument pool (revolving fund tranche, grant award, bond capitalization)"
+        }
+      ]
+    },
+    {
+      "version": "v0.1.1",
+      "date": "2026-05-04",
+      "summary": "Peer review response — vocabulary alignment with UNDRR HIPs 2025, ICLEI pathways, EbA/CbA, informal urban systems, housing tenure, AF/GCF accreditation",
+      "changes": [
+        {
+          "type": "changed",
+          "text": "hazards.json restructured top-level from C40/Arup-primary to UNDRR HIPs 2025-primary (7 clusters: meteorological_hydrological, geohazards, environmental, biological, chemical, technological, societal)"
+        },
+        {
+          "type": "added",
+          "text": "Technological hazard cluster (cyber attack, power outage, infrastructure failure, nuclear incident) promoted from rcc_non_climate to first-class HIPs cluster"
+        },
+        {
+          "type": "added",
+          "text": "Societal hazard cluster (riot/civil unrest, terrorist attack, financial/economic crisis) promoted from rcc_non_climate to first-class HIPs cluster"
+        },
+        {
+          "type": "changed",
+          "text": "Tsunami reclassified from wave_action to geohazards per HIPs 2025 (geophysical trigger, not meteorological)"
+        },
+        {
+          "type": "added",
+          "text": "Hazard.c40_arup_category backref added to every hazard for legacy crosswalk"
+        },
+        {
+          "type": "added",
+          "text": "solution-categories.json: iclei_pathways[] mapping to ICLEI's five urban-development pathways (low-emission, nature-based, circular, resilient, equitable_people_centered) on each category"
+        },
+        {
+          "type": "added",
+          "text": "Solution subcategory: Ecosystem-based Adaptation (EbA) under nature"
+        },
+        {
+          "type": "added",
+          "text": "Solution subcategory: Community-based Adaptation (CbA) under communication_and_community"
+        },
+        {
+          "type": "added",
+          "text": "urban-systems.json: informal_service_systems subsector under socioeconomic_health (informal water, sanitation, solid waste, transport, energy, food, community-led disaster response) — addresses IPCC AR6 Ch. 6 critique that ISO 37120 misses informal urban systems"
+        },
+        {
+          "type": "added",
+          "text": "vulnerable-populations.json: housing-tenure axis entries (manufactured_mobile_home_residents, cooperative_condo_residents, tenure_insecure_residents) per Shelters in the Storm (2025)"
+        },
+        {
+          "type": "added",
+          "text": "FinancingSource.accreditation_modality property + accreditation_modality enum (NIE, RIE, MIE, direct_access, enhanced_direct_access, pooled_facility, readiness_programme) per AF/GCF access framework"
+        },
+        {
+          "type": "fixed",
+          "text": "Resolved conceptual confusion in peer review: AF/GCF terminology (NIEs, direct access, pooled facilities) belongs on FinancingSource, not on mechanism_vocabulary, which describes operational adaptation processes (absorb/redirect/harden/etc.) — left mechanism_vocabulary unchanged"
+        }
+      ]
+    },
+    {
+      "version": "v0.1",
+      "date": "2026-04-30",
+      "summary": "Initial public release",
+      "changes": [
+        {
+          "type": "added",
+          "text": "20 entity types and 45 relationships modeling urban climate adaptation: Solution, Hazard, Vulnerability, ExposureUnit, Plan, Action, Stakeholder, GovernanceStructure, Location, FinancingSource, FinancialInstrument, Mechanism, UrbanSystem, ResilienceGoal, Indicator, Outcome, Barrier, EnablingCondition, PlanningData, Supplier"
+        },
+        {
+          "type": "added",
+          "text": "IPCC AR6 risk-reduction pathways: Solution MITIGATES Hazard, REDUCES_EXPOSURE ExposureUnit, REDUCES Vulnerability"
+        },
+        {
+          "type": "added",
+          "text": "Six controlled vocabularies: hazards (C40/Arup + RCC + UNDRR crosswalk), solution-categories (corpus-mined), urban-systems (ISO 37120-aligned), vulnerable-populations (IPCC AR6/UNDRR/EDF), CRF goals, enums"
+        },
+        {
+          "type": "added",
+          "text": "Provenance model: every extracted value traces to a Claim with source URL, source_type, and confidence"
+        }
+      ]
+    }
+  ]
+}

--- a/ontology/versions.json
+++ b/ontology/versions.json
@@ -1,5 +1,10 @@
 [
   {
+    "path": "../ontology/ontology-v0.6.json",
+    "label": "v0.6",
+    "value": "v0.6"
+  },
+  {
     "path": "../ontology/ontology-v0.5.1.json",
     "label": "v0.5.1",
     "value": "v0.5.1"


### PR DESCRIPTION
## Summary

Ontology **v0.6** (minor — schema change). Adds six relationship rows so CDP city-action and 2024 resilience fact-table data map to real, queryable graph edges instead of being downgraded to plan-level statements, mis-attributed, or buried in a property. Reuses existing relationship ids across new `(source, target)` pairs — the established duplicate-id convention (viewer keys edges by `id + source + target`).

| Source → Target | id | CDP / fact-table field |
|---|---|---|
| Action → Hazard | `ADDRESSES` | `climate_hazard_s_that_action` |
| ResilienceGoal → Hazard | `ADDRESSES` | `goal_hazards` |
| Action → UrbanSystem | `TARGETS` | `sectors_adaptation_action` |
| CapitalProject → UrbanSystem | `TARGETS` | `project_area` |
| Action → FinancingSource | `FUNDED_BY` | `funding_source_s` |
| CapitalProject → FinancingSource | `FUNDED_BY` | *(latent-bug fix)* |

## Notable

- **`FUNDED_BY` is defined for the first time.** It was referenced from v0.2 (change_history, the "Resilience Finance — Five-Axis Split" design note, the `USES_INSTRUMENT` notes, and the framework crosswalk's `FUNDED_BY.amount_usd`) but no relationship object ever existed. v0.6 lands both the Action and the long-referenced CapitalProject rows.
- **`CapitalProject TARGETS UrbanSystem` refines the v0.2 "edge economy" decision** — promotes system domain from the `asset_class` property to a queryable edge (uses `TARGETS`, not Solution-grain `OPERATES_ON`). The v0.2 design note is updated to record the reversal.
- **Corrected drifted metadata counts**: `relationships_count` 51 → 60 (the v0.5.1 array already held 54 rows) and `types_count` 21 → 22 (`Place`, added in v0.5.0, was never counted).

## Files

- `ontology/ontology-v0.6.json` (new) — 6 rows; entity-note updates (Action / ResilienceGoal / CapitalProject); revised + new design notes; new `version_notes` / `change_history`.
- `ontology/versions.json` — v0.6 prepended.
- `ontology/decisions-log.md` — Decision 30 (full rationale).
- `ontology/framework-crosswalk.md` — CDP action/goal/project-grain field→edge table in §3.
- `CLAUDE.md` / `README.md` — current version → v0.6.

## Verification

- Valid JSON; `rows == declared` (60); `types == declared` (22); every source/target resolves to a defined type; all 6 new rows present; `FUNDED_BY` resolves.
- `graph.js` has no hardcoded relationship-id list → no viewer code change needed; all 22 types already have cluster assignments.
- Static-server smoke test: `versions.json` lists v0.6 first, `ontology-v0.6.json` serves with `version: v0.6`, viewer loads (HTTP 200).

🤖 Generated with [Claude Code](https://claude.com/claude-code)