### PR TITLE
fix(viewer): widen edge click hit tolerance

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -9,7 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Instrument+Serif:ital@0;1&family=Inter+Tight:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles/tokens.css" />
-<link rel="stylesheet" href="styles/app.css?v=ui10" />
+<link rel="stylesheet" href="styles/app.css?v=ui11" />
 <script src="https://unpkg.com/d3-selection@3"></script>
 <script src="https://unpkg.com/d3-force@3"></script>
 <script src="https://unpkg.com/d3-drag@3"></script>
@@ -127,11 +127,11 @@
   </div>
 </div>
 
-<script src="scripts/ontology-adapter.js?v=ui10"></script>
-<script src="scripts/comments.js?v=ui10"></script>
-<script src="scripts/graph.js?v=ui10"></script>
-<script src="scripts/inspector.js?v=ui10"></script>
-<script src="scripts/app.js?v=ui10"></script>
+<script src="scripts/ontology-adapter.js?v=ui11"></script>
+<script src="scripts/comments.js?v=ui11"></script>
+<script src="scripts/graph.js?v=ui11"></script>
+<script src="scripts/inspector.js?v=ui11"></script>
+<script src="scripts/app.js?v=ui11"></script>
 
 </body>
 </html>

--- a/viewer/scripts/graph.js
+++ b/viewer/scripts/graph.js
@@ -746,8 +746,10 @@
     return null;
   }
 
+  const EDGE_HIT_TOLERANCE_PX = 14; // screen-space, independent of zoom
+
   function edgeAt(wx, wy) {
-    let best = null, bestDist = 6; // world-space tolerance
+    let best = null, bestDist = EDGE_HIT_TOLERANCE_PX / transform.k;
     for (const l of links) {
       if (l.source === l.target) continue;
       if (!isClusterOn(l.source.cluster) || !isClusterOn(l.target.cluster)) continue;


### PR DESCRIPTION
## Summary
- Edge click hit-testing used a fixed 6-world-unit tolerance that wasn't scaled by zoom, so at the graph's default fit-to-view zoom (~0.41x) the actual clickable area around an edge was only ~2.5 screen pixels wide — effectively impossible to hit with a real mouse.
- Tolerance is now 14 screen pixels, converted to world space via the current zoom level, so edges stay reliably clickable regardless of zoom.
- Bumped the viewer's cache-busting query param (`?v=ui10` → `?v=ui11`) so the deployed site picks up the fix instead of a cached copy.

## Test plan
- [x] Verified locally that hovering/clicking several pixels off an edge's true line now resolves to the nearest edge (previously required near pixel-perfect precision)
- [x] Verified fix also holds on the deployed site's current bundled code path (same hit-test function)