### PR TITLE
Fix relationship detail and focused-node navigation

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -129,8 +129,8 @@
 
 <script src="scripts/ontology-adapter.js?v=ui11"></script>
 <script src="scripts/comments.js?v=ui11"></script>
-<script src="scripts/graph.js?v=ui11"></script>
-<script src="scripts/inspector.js?v=ui11"></script>
+<script src="scripts/graph.js?v=ui12"></script>
+<script src="scripts/inspector.js?v=ui12"></script>
 <script src="scripts/app.js?v=ui11"></script>
 
 </body>

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -129,7 +129,7 @@
 
 <script src="scripts/ontology-adapter.js?v=ui11"></script>
 <script src="scripts/comments.js?v=ui11"></script>
-<script src="scripts/graph.js?v=ui12"></script>
+<script src="scripts/graph.js?v=ui13"></script>
 <script src="scripts/inspector.js?v=ui12"></script>
 <script src="scripts/app.js?v=ui11"></script>
 

--- a/viewer/scripts/graph.js
+++ b/viewer/scripts/graph.js
@@ -1141,7 +1141,6 @@
   }
 
   function selectEdge(l) {
-    if (focusMode) { deselect(); return; }
     selectedEdge = l;
     selectedNode = null;
     draw();

--- a/viewer/scripts/graph.js
+++ b/viewer/scripts/graph.js
@@ -1063,9 +1063,11 @@
 
   function selectNode(n) {
     selectedEdge = null;
+    const wasFocused = focusMode;
 
-    // If already in focus mode, deselect first (spring back), don't re-focus
-    if (focusMode) {
+    // Clicking the current center exits focus mode. Clicking a neighbor makes
+    // that node the new center while preserving the original layout for Close.
+    if (wasFocused && selectedNode === n) {
       deselect();
       return;
     }
@@ -1075,10 +1077,17 @@
 
     selectedNode = n;
 
-    // Stash current positions and transform
-    stashedPositions = new Map();
-    for (const nd of nodes) stashedPositions.set(nd.id, { x: nd.x, y: nd.y });
-    stashedTransform = { ...transform };
+    // Stash the full-graph layout only on first entry into focus mode.
+    // Subsequent node-to-node navigation must keep the same return point.
+    if (!wasFocused) {
+      stashedPositions = new Map();
+      for (const nd of nodes) stashedPositions.set(nd.id, { x: nd.x, y: nd.y });
+      stashedTransform = { ...transform };
+    }
+
+    const startPositions = new Map();
+    for (const nd of nodes) startPositions.set(nd.id, { x: nd.x, y: nd.y });
+    const startTransform = { ...transform };
 
     // Compute 1-hop subgraph
     const neighborIds = new Set();
@@ -1118,11 +1127,9 @@
     };
 
     focusMode = true;
-    const startPositions = new Map(stashedPositions);
-    const startTransform = { ...stashedTransform };
 
     animateTransition(400, (ease) => {
-      focusProgress = ease;
+      focusProgress = wasFocused ? 1 : ease;
       for (const nd of nodes) {
         const from = startPositions.get(nd.id);
         const to = targetPositions.get(nd.id);

--- a/viewer/scripts/inspector.js
+++ b/viewer/scripts/inspector.js
@@ -193,7 +193,7 @@
                   const srcLabel = out ? n.label : other.label;
                   const tgtLabel = out ? other.label : n.label;
                   const selfIsSrc = out;
-                  return `<li class="rel-item" data-nid="${esc(other.id)}" data-eid="${esc(l.id)}">
+                  return `<li class="rel-item" data-source-id="${esc(l.source.id)}" data-target-id="${esc(l.target.id)}" data-eid="${esc(l.id)}">
                     <span class="rel-sentence">
                       <span class="${selfIsSrc ? 'rel-self' : 'rel-other'}" ${!selfIsSrc ? `style="color:${color}"` : ''}>${esc(srcLabel)}</span>
                       <span class="rel-label">${esc(l.label)}</span>
@@ -372,7 +372,14 @@
       li.addEventListener('click', () => window.Graph.focusNode(li.dataset.nid));
     });
     el().querySelectorAll('.rel-item').forEach(li => {
-      li.addEventListener('click', () => window.Graph.focusNode(li.dataset.nid));
+      li.addEventListener('click', () => {
+        const edge = window.Graph.getLinks().find(l =>
+          l.id === li.dataset.eid &&
+          l.source.id === li.dataset.sourceId &&
+          l.target.id === li.dataset.targetId
+        );
+        if (edge) window.Graph.selectEdge(edge);
+      });
     });
   }
 


### PR DESCRIPTION
## What changed

- Open the exact relationship detail when clicking an entity's relationship list item.
- Match relationships by `id + source + target`, since relationship IDs are not globally unique.
- Keep the focused graph active when selecting a relationship.
- Allow clicking a peripheral node to make it the new focused center.
- Preserve the original full-graph layout so clicking the current center or closing details returns cleanly.
- Bump viewer script cache keys for the updated behavior.

## Why

Relationship list clicks previously navigated to the neighboring entity, and selecting an edge or another node while focused reset the graph to its initial state. This made graph exploration feel discontinuous.

## Validation

- `node --check viewer/scripts/graph.js`
- `node --check viewer/scripts/inspector.js`
- `git diff --check`
