### PR TITLE
fix(viewer): open exact relationship from entity relationship list

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -9,7 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Instrument+Serif:ital@0;1&family=Inter+Tight:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles/tokens.css" />
-<link rel="stylesheet" href="styles/app.css?v=ui12" />
+<link rel="stylesheet" href="styles/app.css?v=ui13" />
 <script src="https://unpkg.com/d3-selection@3"></script>
 <script src="https://unpkg.com/d3-force@3"></script>
 <script src="https://unpkg.com/d3-drag@3"></script>
@@ -127,11 +127,11 @@
   </div>
 </div>
 
-<script src="scripts/ontology-adapter.js?v=ui12"></script>
-<script src="scripts/comments.js?v=ui12"></script>
-<script src="scripts/graph.js?v=ui12"></script>
-<script src="scripts/inspector.js?v=ui12"></script>
-<script src="scripts/app.js?v=ui12"></script>
+<script src="scripts/ontology-adapter.js?v=ui13"></script>
+<script src="scripts/comments.js?v=ui13"></script>
+<script src="scripts/graph.js?v=ui13"></script>
+<script src="scripts/inspector.js?v=ui13"></script>
+<script src="scripts/app.js?v=ui13"></script>
 
 </body>
 </html>

--- a/viewer/scripts/inspector.js
+++ b/viewer/scripts/inspector.js
@@ -193,7 +193,7 @@
                   const srcLabel = out ? n.label : other.label;
                   const tgtLabel = out ? other.label : n.label;
                   const selfIsSrc = out;
-                  return `<li class="rel-item" data-nid="${esc(other.id)}" data-eid="${esc(l.id)}">
+                  return `<li class="rel-item" data-source-id="${esc(l.source.id)}" data-target-id="${esc(l.target.id)}" data-eid="${esc(l.id)}">
                     <span class="rel-sentence">
                       <span class="${selfIsSrc ? 'rel-self' : 'rel-other'}" ${!selfIsSrc ? `style="color:${color}"` : ''}>${esc(srcLabel)}</span>
                       <span class="rel-label">${esc(l.label)}</span>
@@ -372,7 +372,15 @@
       li.addEventListener('click', () => window.Graph.focusNode(li.dataset.nid));
     });
     el().querySelectorAll('.rel-item').forEach(li => {
-      li.addEventListener('click', () => window.Graph.focusNode(li.dataset.nid));
+      li.addEventListener('click', () => {
+        // Relationship ids aren't globally unique, so match on id + endpoints.
+        const edge = window.Graph.getLinks().find(l =>
+          l.id === li.dataset.eid &&
+          l.source.id === li.dataset.sourceId &&
+          l.target.id === li.dataset.targetId
+        );
+        if (edge) window.Graph.selectEdge(edge);
+      });
     });
   }
 


### PR DESCRIPTION
## Summary
- Clicking a relationship in an entity's relationship list previously jumped to the neighboring node instead of opening that specific relationship's detail.
- Relationship ids aren't globally unique, so the list item now carries its source/target endpoints (`data-source-id`/`data-target-id`) and the click handler looks up the exact edge by `id + source + target` before calling `Graph.selectEdge(edge)`.
- Bumped the cache-busting asset version (`?v=ui12` → `?v=ui13`).

Ported from the relevant half of #11 (external contribution). That PR's other change — focused-node re-navigation — was already fixed and merged in #12, so #11 now conflicts with `main`; this PR carries forward just the still-needed relationship-list part. Closing #11 with an explanation as a followup.

## Test plan
- [x] Focus a node, click a relationship in its relationship list → inspector opens that exact relationship's detail (not the neighboring node)
- [x] `node --check` on both changed scripts