### PR TITLE
fix(viewer): stop version switch from crashing on stale selection or unmapped cluster

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -9,7 +9,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600;9..144,700&family=Instrument+Serif:ital@0;1&family=Inter+Tight:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="styles/tokens.css" />
-<link rel="stylesheet" href="styles/app.css?v=ui13" />
+<link rel="stylesheet" href="styles/app.css?v=ui14" />
 <script src="https://unpkg.com/d3-selection@3"></script>
 <script src="https://unpkg.com/d3-force@3"></script>
 <script src="https://unpkg.com/d3-drag@3"></script>
@@ -127,11 +127,11 @@
   </div>
 </div>
 
-<script src="scripts/ontology-adapter.js?v=ui13"></script>
-<script src="scripts/comments.js?v=ui13"></script>
-<script src="scripts/graph.js?v=ui13"></script>
-<script src="scripts/inspector.js?v=ui13"></script>
-<script src="scripts/app.js?v=ui13"></script>
+<script src="scripts/ontology-adapter.js?v=ui14"></script>
+<script src="scripts/comments.js?v=ui14"></script>
+<script src="scripts/graph.js?v=ui14"></script>
+<script src="scripts/inspector.js?v=ui14"></script>
+<script src="scripts/app.js?v=ui14"></script>
 
 </body>
 </html>

--- a/viewer/scripts/graph.js
+++ b/viewer/scripts/graph.js
@@ -177,7 +177,7 @@
         }
       }
 
-      sectorBoundaries.push({ cluster, startAngle, endAngle, color: CLUSTER_COLORS[cluster] });
+      sectorBoundaries.push({ cluster, startAngle, endAngle, color: colorFor(cluster) });
       cursor = endAngle + gapArc;
     }
   }
@@ -1274,6 +1274,23 @@
   function load(graphData) {
     window.ONTOLOGY = graphData;
     if (simulation) simulation.stop();
+    if (focusAnimFrame) { cancelAnimationFrame(focusAnimFrame); focusAnimFrame = null; }
+
+    // Selection/focus state references nodes and links from the previous
+    // version's data. Entity ids can be added, removed, or renamed between
+    // versions (e.g. GovernanceStructure removed in v0.7), so a stale
+    // reference left over from before a version switch can point at
+    // something that no longer exists — reset everything up front.
+    hoverNode = null; hoverEdge = null;
+    selectedNode = null; selectedEdge = null;
+    dragNode = null; dragStart = null;
+    isPanning = false; panStart = null;
+    focusMode = false;
+    focusProgress = 0;
+    stashedPositions = null;
+    stashedTransform = null;
+    focusSubgraphIds = new Set();
+
     transform = { x: 0, y: 0, k: 1 };
     setup(graphData);
     resize();

--- a/viewer/scripts/ontology-adapter.js
+++ b/viewer/scripts/ontology-adapter.js
@@ -9,6 +9,7 @@
     'Barrier': 'Risk',
     // Context — where solutions operate and who governs them
     'Jurisdiction': 'Context',
+    'Location': 'Context', // pre-v0.5.0 name for Jurisdiction
     'Place': 'Context',
     'UrbanSystem': 'Context',
     'Stakeholder': 'Context',


### PR DESCRIPTION
## Summary
Found while reviewing #9 (v0.7 removes `GovernanceStructure`): switching the version dropdown while a node/edge is selected can crash the viewer entirely.

Two separate causes, both fixed here:

1. **Stale selection across a version swap.** `load()` never cleared `selectedNode`/`selectedEdge`/focus-mode state. If you select an entity in one version then switch to a version where that id doesn't exist (renamed or removed — e.g. `GovernanceStructure` in v0.7, or `Location`→`Jurisdiction` in v0.5.0), `nodeIsDim()` throws on the stale `linksByNode` lookup and rendering stops. `load()` now resets all selection/hover/focus state before loading the new graph, since none of it carries meaning across a version swap.
2. **Unmapped cluster crashes the sector-wedge draw, independent of selection.** Loading any version with a type missing from `CLUSTER_ASSIGNMENTS` crashes on `undefined.slice()` in the sector-wedge fill code, which read `CLUSTER_COLORS[cluster]` directly instead of the `colorFor()` helper that already has a safe fallback. Checked all 10 historical ontology files — `Location` (pre-v0.5.0 name for `Jurisdiction`) is the only gap, affecting v0.1 through v0.4.1. Fixed the lookup to go through `colorFor()`, and added the missing `Location → Context` mapping.

Bumped the cache-busting asset version (`?v=ui13` → `?v=ui14`).

## Test plan
- [x] Select `Jurisdiction` under v0.6.1, switch to v0.4 (predates the rename) → previously crashed the whole graph, now switches cleanly with `Location` selectable and inspectable
- [x] Load v0.4 directly with no prior selection → previously crashed on load, now renders with `Location` in the Context cluster
- [x] Verified via script that `Location` is the only type id across all `ontology-v*.json` files missing from `CLUSTER_ASSIGNMENTS`